### PR TITLE
Define runner for all workers

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager.rb
+++ b/app/models/manageiq/providers/azure/network_manager.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::Azure::NetworkManager < ManageIQ::Providers::NetworkManager
   require_nested :CloudNetwork
   require_nested :CloudSubnet
+  require_nested :EventCatcher
   require_nested :FloatingIp
   require_nested :LoadBalancer
   require_nested :LoadBalancerHealthCheck

--- a/app/models/manageiq/providers/azure/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/azure/network_manager/event_catcher.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Azure::NetworkManager::EventCatcher < ::MiqEventCatcher
+  require_nested :Runner
+
   def self.ems_class
     ManageIQ::Providers::Azure::NetworkManager
   end

--- a/app/models/manageiq/providers/azure/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/network_manager/event_catcher/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Azure::NetworkManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+end

--- a/app/models/manageiq/providers/azure/network_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/azure/network_manager/metrics_collector_worker.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Azure::NetworkManager::MetricsCollectorWorker < ::MiqEmsMetricsCollectorWorker
+  require_nested :Runner
+
   self.default_queue_name = "azure_network"
 
   def friendly_name

--- a/app/models/manageiq/providers/azure/network_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/azure/network_manager/metrics_collector_worker/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Azure::NetworkManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
+end


### PR DESCRIPTION
There is currently a requirement that all workers have a runner.
Also added missing loading for our event_catchers

Making this consistent across projects

This was split off of https://github.com/ManageIQ/manageiq/pull/12461