### PR TITLE
Set Azure log to $azure_log

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -34,7 +34,9 @@ module ManageIQ::Providers::Azure::ManagerMixin
         raise MiqException::MiqInvalidCredentialsError, _("Incorrect credentials - check your Azure Subscription ID")
       end
 
-      ::Azure::Armrest::ArmrestService.configure(
+      ::Azure::Armrest::Configuration.log = $azure_log
+
+      ::Azure::Armrest::Configuration.new(
         :client_id       => client_id,
         :client_key      => client_key,
         :tenant_id       => azure_tenant_id,


### PR DESCRIPTION
Set the Azure log to $azure_log. This will log the http requests being made by the azure-armrest gem.

Possible issues include the fact that there's a single, global log for rest-client which could be overwritten, and the fact that I cannot currently apply a filter to the Logger instance because of https://github.com/rest-client/rest-client/pull/543.