### PR TITLE
remove not needed module with incorrect spelling

### DIFF
--- a/lib/manageiq/providers/azure.rb
+++ b/lib/manageiq/providers/azure.rb
@@ -1,8 +1,1 @@
 require "manageiq/providers/azure/engine"
-
-module Manageiq
-  module Providers
-    module Azure
-    end
-  end
-end


### PR DESCRIPTION
this sneaked in somehow.

azure/engine.rb is defining the modules already.