### PR TITLE
Initial setup of locale files for ManageIQ::Providers::Azure

### DIFF
--- a/locale/ManageIQ_Providers_Azure.pot
+++ b/locale/ManageIQ_Providers_Azure.pot
@@ -1,0 +1,155 @@
+# Gettext catalog for ManageIQ Azure provider plugin
+# Copyright (C) 2016
+# This file is distributed under the same license as the ManageIQ_Providers_Azure package.
+# Milan Zázrivec <mzazrivec@redhat.com>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: ManageIQ_Providers_Azure 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-10 14:18+0100\n"
+"PO-Revision-Date: 2016-11-10 14:18+0100\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: ../app/models/manageiq/providers/azure/manager_mixin.rb:16
+msgid "\"Incorrect credentials - #{err.message}\""
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/manager_mixin.rb:23
+msgid "\"Unexpected response returned from system: #{err.message}\""
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb:66
+msgid "%{name} does not exist on %{management}"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:7
+msgid "Australia East"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:11
+msgid "Australia Southeast"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:15
+msgid "Brazil South"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:19
+msgid "Canada Central"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:23
+msgid "Canada East"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:27
+msgid "Central India"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:31
+msgid "Central US"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:35
+msgid "East Asia"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:39
+msgid "East US"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:43
+msgid "East US 2"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/manager_mixin.rb:18
+msgid "Incorrect credentials - check your Azure Client ID and Client Key"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/manager_mixin.rb:34
+msgid "Incorrect credentials - check your Azure Subscription ID"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:47
+msgid "Japan East"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:51
+msgid "Japan West"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/manager_mixin.rb:5
+msgid "No credentials defined"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:55
+msgid "North Central US"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:59
+msgid "North Europe"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb:17
+msgid "Pause Operation"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:63
+msgid "South Central US"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:67
+msgid "South East Asia"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:71
+msgid "South India"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb:7
+msgid "The VM is not powered on"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:75
+msgid "US Gov Iowa"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:79
+msgid "US Gov Virginia"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb:7
+msgid "VM has no %{table}, unable to destroy VM"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:91
+msgid "West Central US"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:83
+msgid "West Europe"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:87
+msgid "West India"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:95
+msgid "West US"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/regions.rb:99
+msgid "West US 2"
+msgstr ""
+
+#: ../app/models/manageiq/providers/azure/cloud_manager/template.rb:8
+msgid "not connected to ems"
+msgstr ""

--- a/locale/en/ManageIQ_Providers_Azure.po
+++ b/locale/en/ManageIQ_Providers_Azure.po
@@ -1,0 +1,120 @@
+# English translations for ManageIQ_Providers_Azure package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ManageIQ_Providers_Azure package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ManageIQ_Providers_Azure 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-11-10 14:18+0100\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"\n"
+
+msgid "\"Incorrect credentials - #{err.message}\""
+msgstr ""
+
+msgid "\"Unexpected response returned from system: #{err.message}\""
+msgstr ""
+
+msgid "%{name} does not exist on %{management}"
+msgstr ""
+
+msgid "Australia East"
+msgstr ""
+
+msgid "Australia Southeast"
+msgstr ""
+
+msgid "Brazil South"
+msgstr ""
+
+msgid "Canada Central"
+msgstr ""
+
+msgid "Canada East"
+msgstr ""
+
+msgid "Central India"
+msgstr ""
+
+msgid "Central US"
+msgstr ""
+
+msgid "East Asia"
+msgstr ""
+
+msgid "East US"
+msgstr ""
+
+msgid "East US 2"
+msgstr ""
+
+msgid "Incorrect credentials - check your Azure Client ID and Client Key"
+msgstr ""
+
+msgid "Incorrect credentials - check your Azure Subscription ID"
+msgstr ""
+
+msgid "Japan East"
+msgstr ""
+
+msgid "Japan West"
+msgstr ""
+
+msgid "No credentials defined"
+msgstr ""
+
+msgid "North Central US"
+msgstr ""
+
+msgid "North Europe"
+msgstr ""
+
+msgid "Pause Operation"
+msgstr ""
+
+msgid "South Central US"
+msgstr ""
+
+msgid "South East Asia"
+msgstr ""
+
+msgid "South India"
+msgstr ""
+
+msgid "The VM is not powered on"
+msgstr ""
+
+msgid "US Gov Iowa"
+msgstr ""
+
+msgid "US Gov Virginia"
+msgstr ""
+
+msgid "VM has no %{table}, unable to destroy VM"
+msgstr ""
+
+msgid "West Central US"
+msgstr ""
+
+msgid "West Europe"
+msgstr ""
+
+msgid "West India"
+msgstr ""
+
+msgid "West US"
+msgstr ""
+
+msgid "West US 2"
+msgstr ""
+
+msgid "not connected to ems"
+msgstr ""

--- a/locale/es/ManageIQ_Providers_Azure.po
+++ b/locale/es/ManageIQ_Providers_Azure.po
@@ -1,0 +1,120 @@
+# Spanish translations for ManageIQ_Providers_Azure package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ManageIQ_Providers_Azure package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ManageIQ_Providers_Azure 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-11-10 14:18+0100\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"\n"
+
+msgid "\"Incorrect credentials - #{err.message}\""
+msgstr ""
+
+msgid "\"Unexpected response returned from system: #{err.message}\""
+msgstr ""
+
+msgid "%{name} does not exist on %{management}"
+msgstr ""
+
+msgid "Australia East"
+msgstr ""
+
+msgid "Australia Southeast"
+msgstr ""
+
+msgid "Brazil South"
+msgstr ""
+
+msgid "Canada Central"
+msgstr ""
+
+msgid "Canada East"
+msgstr ""
+
+msgid "Central India"
+msgstr ""
+
+msgid "Central US"
+msgstr ""
+
+msgid "East Asia"
+msgstr ""
+
+msgid "East US"
+msgstr ""
+
+msgid "East US 2"
+msgstr ""
+
+msgid "Incorrect credentials - check your Azure Client ID and Client Key"
+msgstr ""
+
+msgid "Incorrect credentials - check your Azure Subscription ID"
+msgstr ""
+
+msgid "Japan East"
+msgstr ""
+
+msgid "Japan West"
+msgstr ""
+
+msgid "No credentials defined"
+msgstr ""
+
+msgid "North Central US"
+msgstr ""
+
+msgid "North Europe"
+msgstr ""
+
+msgid "Pause Operation"
+msgstr ""
+
+msgid "South Central US"
+msgstr ""
+
+msgid "South East Asia"
+msgstr ""
+
+msgid "South India"
+msgstr ""
+
+msgid "The VM is not powered on"
+msgstr ""
+
+msgid "US Gov Iowa"
+msgstr ""
+
+msgid "US Gov Virginia"
+msgstr ""
+
+msgid "VM has no %{table}, unable to destroy VM"
+msgstr ""
+
+msgid "West Central US"
+msgstr ""
+
+msgid "West Europe"
+msgstr ""
+
+msgid "West India"
+msgstr ""
+
+msgid "West US"
+msgstr ""
+
+msgid "West US 2"
+msgstr ""
+
+msgid "not connected to ems"
+msgstr ""

--- a/locale/fr/ManageIQ_Providers_Azure.po
+++ b/locale/fr/ManageIQ_Providers_Azure.po
@@ -1,0 +1,120 @@
+# French translations for ManageIQ_Providers_Azure package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ManageIQ_Providers_Azure package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ManageIQ_Providers_Azure 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-11-10 14:18+0100\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: French\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n>1;\n"
+"\n"
+
+msgid "\"Incorrect credentials - #{err.message}\""
+msgstr ""
+
+msgid "\"Unexpected response returned from system: #{err.message}\""
+msgstr ""
+
+msgid "%{name} does not exist on %{management}"
+msgstr ""
+
+msgid "Australia East"
+msgstr ""
+
+msgid "Australia Southeast"
+msgstr ""
+
+msgid "Brazil South"
+msgstr ""
+
+msgid "Canada Central"
+msgstr ""
+
+msgid "Canada East"
+msgstr ""
+
+msgid "Central India"
+msgstr ""
+
+msgid "Central US"
+msgstr ""
+
+msgid "East Asia"
+msgstr ""
+
+msgid "East US"
+msgstr ""
+
+msgid "East US 2"
+msgstr ""
+
+msgid "Incorrect credentials - check your Azure Client ID and Client Key"
+msgstr ""
+
+msgid "Incorrect credentials - check your Azure Subscription ID"
+msgstr ""
+
+msgid "Japan East"
+msgstr ""
+
+msgid "Japan West"
+msgstr ""
+
+msgid "No credentials defined"
+msgstr ""
+
+msgid "North Central US"
+msgstr ""
+
+msgid "North Europe"
+msgstr ""
+
+msgid "Pause Operation"
+msgstr ""
+
+msgid "South Central US"
+msgstr ""
+
+msgid "South East Asia"
+msgstr ""
+
+msgid "South India"
+msgstr ""
+
+msgid "The VM is not powered on"
+msgstr ""
+
+msgid "US Gov Iowa"
+msgstr ""
+
+msgid "US Gov Virginia"
+msgstr ""
+
+msgid "VM has no %{table}, unable to destroy VM"
+msgstr ""
+
+msgid "West Central US"
+msgstr ""
+
+msgid "West Europe"
+msgstr ""
+
+msgid "West India"
+msgstr ""
+
+msgid "West US"
+msgstr ""
+
+msgid "West US 2"
+msgstr ""
+
+msgid "not connected to ems"
+msgstr ""

--- a/locale/ja/ManageIQ_Providers_Azure.po
+++ b/locale/ja/ManageIQ_Providers_Azure.po
@@ -1,0 +1,120 @@
+# Japanese translations for ManageIQ_Providers_Azure package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ManageIQ_Providers_Azure package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ManageIQ_Providers_Azure 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-11-10 14:18+0100\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"\n"
+
+msgid "\"Incorrect credentials - #{err.message}\""
+msgstr ""
+
+msgid "\"Unexpected response returned from system: #{err.message}\""
+msgstr ""
+
+msgid "%{name} does not exist on %{management}"
+msgstr ""
+
+msgid "Australia East"
+msgstr ""
+
+msgid "Australia Southeast"
+msgstr ""
+
+msgid "Brazil South"
+msgstr ""
+
+msgid "Canada Central"
+msgstr ""
+
+msgid "Canada East"
+msgstr ""
+
+msgid "Central India"
+msgstr ""
+
+msgid "Central US"
+msgstr ""
+
+msgid "East Asia"
+msgstr ""
+
+msgid "East US"
+msgstr ""
+
+msgid "East US 2"
+msgstr ""
+
+msgid "Incorrect credentials - check your Azure Client ID and Client Key"
+msgstr ""
+
+msgid "Incorrect credentials - check your Azure Subscription ID"
+msgstr ""
+
+msgid "Japan East"
+msgstr ""
+
+msgid "Japan West"
+msgstr ""
+
+msgid "No credentials defined"
+msgstr ""
+
+msgid "North Central US"
+msgstr ""
+
+msgid "North Europe"
+msgstr ""
+
+msgid "Pause Operation"
+msgstr ""
+
+msgid "South Central US"
+msgstr ""
+
+msgid "South East Asia"
+msgstr ""
+
+msgid "South India"
+msgstr ""
+
+msgid "The VM is not powered on"
+msgstr ""
+
+msgid "US Gov Iowa"
+msgstr ""
+
+msgid "US Gov Virginia"
+msgstr ""
+
+msgid "VM has no %{table}, unable to destroy VM"
+msgstr ""
+
+msgid "West Central US"
+msgstr ""
+
+msgid "West Europe"
+msgstr ""
+
+msgid "West India"
+msgstr ""
+
+msgid "West US"
+msgstr ""
+
+msgid "West US 2"
+msgstr ""
+
+msgid "not connected to ems"
+msgstr ""

--- a/locale/zh_CN/ManageIQ_Providers_Azure.po
+++ b/locale/zh_CN/ManageIQ_Providers_Azure.po
@@ -1,0 +1,120 @@
+# Chinese translations for ManageIQ_Providers_Azure package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ManageIQ_Providers_Azure package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ManageIQ_Providers_Azure 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-11-10 14:18+0100\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Chinese\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"\n"
+
+msgid "\"Incorrect credentials - #{err.message}\""
+msgstr ""
+
+msgid "\"Unexpected response returned from system: #{err.message}\""
+msgstr ""
+
+msgid "%{name} does not exist on %{management}"
+msgstr ""
+
+msgid "Australia East"
+msgstr ""
+
+msgid "Australia Southeast"
+msgstr ""
+
+msgid "Brazil South"
+msgstr ""
+
+msgid "Canada Central"
+msgstr ""
+
+msgid "Canada East"
+msgstr ""
+
+msgid "Central India"
+msgstr ""
+
+msgid "Central US"
+msgstr ""
+
+msgid "East Asia"
+msgstr ""
+
+msgid "East US"
+msgstr ""
+
+msgid "East US 2"
+msgstr ""
+
+msgid "Incorrect credentials - check your Azure Client ID and Client Key"
+msgstr ""
+
+msgid "Incorrect credentials - check your Azure Subscription ID"
+msgstr ""
+
+msgid "Japan East"
+msgstr ""
+
+msgid "Japan West"
+msgstr ""
+
+msgid "No credentials defined"
+msgstr ""
+
+msgid "North Central US"
+msgstr ""
+
+msgid "North Europe"
+msgstr ""
+
+msgid "Pause Operation"
+msgstr ""
+
+msgid "South Central US"
+msgstr ""
+
+msgid "South East Asia"
+msgstr ""
+
+msgid "South India"
+msgstr ""
+
+msgid "The VM is not powered on"
+msgstr ""
+
+msgid "US Gov Iowa"
+msgstr ""
+
+msgid "US Gov Virginia"
+msgstr ""
+
+msgid "VM has no %{table}, unable to destroy VM"
+msgstr ""
+
+msgid "West Central US"
+msgstr ""
+
+msgid "West Europe"
+msgstr ""
+
+msgid "West India"
+msgstr ""
+
+msgid "West US"
+msgstr ""
+
+msgid "West US 2"
+msgstr ""
+
+msgid "not connected to ems"
+msgstr ""


### PR DESCRIPTION
These files were created by a rake task:

    rake locale:plugin:find[ManageIQ::Providers::Azure]

run from ManageIQ git checkout.