### PR TITLE
Update the case of the Azure event vm_ems_ref property

### DIFF
--- a/app/models/manageiq/providers/azure/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/azure/event_catcher_mixin.rb
@@ -28,8 +28,8 @@ module ManageIQ::Providers::Azure::EventCatcherMixin
     _providers,
     provider,
     object_class,
-    object_name = event["resourceId"].downcase.split("/")
+    object_name = event["resourceId"].split("/")
 
-    [subscription_id, resource_group, "#{provider}\/#{object_class}", object_name].join("\\")
+    [subscription_id, resource_group.downcase, "#{provider.downcase}\/#{object_class.downcase}", object_name].join("\\")
   end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_catcher/runner_spec.rb
@@ -6,7 +6,7 @@ describe ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner do
     let(:event) do
       {"authorization" => {"action" => "Microsoft.Compute/virtualMachines/deallocate/action"},
        "eventName"     => {"value"  => "EndRequest"},
-       "resourceId"    => "/subscriptions/12345/resourceGroups/Rg1/providers/Microsoft.Compute/virtualMachines/testvm"}
+       "resourceId"    => "/subscriptions/12345/resourceGroups/Rg1/providers/Microsoft.Compute/virtualMachines/TestVm"}
     end
 
     before do
@@ -20,7 +20,7 @@ describe ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner do
       end
 
       it "vm ref" do
-        expect(catcher.parse_vm_ref(event)).to eq "12345\\rg1\\microsoft.compute/virtualmachines\\testvm"
+        expect(catcher.parse_vm_ref(event)).to eq "12345\\rg1\\microsoft.compute/virtualmachines\\TestVm"
       end
     end
   end


### PR DESCRIPTION
The ***ems_ref*** value constructed from the resourceID property of an Azure event is used to look up the corresponding VM object in the database. Prior to this PR, this ***ems_ref*** was entirely lowercase, for example:
```123456789-a1234-12b4-1234-5cd67890312/resourcegroupname/microsoft.compute\virtualmachines/testvm```

However, the ems_ref property of the VM in the Vms table is all lowercase except the VM Name piece, for example:
```123456789-a1234-12b4-1234-5cd67890312/resourcegroupname/microsoft.compute\virtualmachines/TestVm```

This case mismatch of the VM name component of the ***ems_ref*** prevented the association between VM and event from being made when a VM name is mixed case.

The VM ***ems_ref*** is referenced throughout the product so it is best not to alter it.



https://bugzilla.redhat.com/show_bug.cgi?id=1390587