### PR TITLE
Filter out Azure events from Classic Providers

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -46,6 +46,10 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     )
   end
 
+  def blacklisted_provider_types
+    %r{Microsoft.Classic}
+  end
+
   def self.hostname_required?
     false
   end

--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -41,7 +41,7 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
 
   def filtered?(event)
     event_type    = parse_event_type(event)
-    provider_type = parse_provider_type(event)
+    provider_type = event["resourceProviderName"]["value"]
 
     @ems.blacklisted_provider_types.match(provider_type)||
     filtered_events.include?(event_type)

--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -40,7 +40,10 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
   end
 
   def filtered?(event)
-    event_type = parse_event_type(event)
+    event_type    = parse_event_type(event)
+    provider_type = parse_provider_type(event)
+
+    @ems.blacklisted_provider_types.match(provider_type)||
     filtered_events.include?(event_type)
   end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -43,7 +43,6 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
     event_type    = parse_event_type(event)
     provider_type = event["resourceProviderName"]["value"]
 
-    @ems.blacklisted_provider_types.match(provider_type)||
-    filtered_events.include?(event_type)
+    @ems.blacklisted_provider_types.match(provider_type) || filtered_events.include?(event_type)
   end
 end

--- a/app/models/manageiq/providers/azure/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/azure/event_catcher_mixin.rb
@@ -14,10 +14,6 @@ module ManageIQ::Providers::Azure::EventCatcherMixin
     "#{object_class}_#{event_type}_"
   end
 
-  def parse_provider_type(event)
-    event["resourceProviderName"]["value"]
-  end
-
   def parse_vm_ref(event)
     # E.g. /subscriptions/123456789-a1234-12b4-1234-5cd67890312/resourceGroups/
     # rg_name/providers/Microsoft.Compute/virtualMachines/vm_name

--- a/app/models/manageiq/providers/azure/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/azure/event_catcher_mixin.rb
@@ -14,6 +14,10 @@ module ManageIQ::Providers::Azure::EventCatcherMixin
     "#{object_class}_#{event_type}_"
   end
 
+  def parse_provider_type(event)
+    event["resourceProviderName"]["value"]
+  end
+
   def parse_vm_ref(event)
     # E.g. /subscriptions/123456789-a1234-12b4-1234-5cd67890312/resourceGroups/
     # rg_name/providers/Microsoft.Compute/virtualMachines/vm_name


### PR DESCRIPTION


We do not support the Azure Classic providers which are part of the older Azure ASM API, yet the event filter does not exclude events from Classic providers, this means we are accepting and storing many unnecessary events.

Fixes https://github.com/ManageIQ/manageiq-providers-azure/issues/11

https://bugzilla.redhat.com/show_bug.cgi?id=1399296