### PR TITLE
Add managers in before_create callback instead of before_validation

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -25,7 +25,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   supports :provisioning
   supports :regions
 
-  before_validation :ensure_managers
+  before_create :ensure_managers
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::Azure::NetworkManager') unless network_manager


### PR DESCRIPTION
otherwise it could happen that one process deletes the manager
and another one saves it and the saving one would add back
a deleted manager.

https://bugzilla.redhat.com/show_bug.cgi?id=1389459
https://bugzilla.redhat.com/show_bug.cgi?id=1393675

