### PR TITLE
Delete VM associated resources (NIC, IP, VHD, .status)

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
@@ -6,7 +6,7 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations
     unless ext_management_system
       raise _("VM has no %{table}, unable to destroy VM") % {:table => ui_lookup(:table => "ext_management_systems")}
     end
-    provider_service.delete(name, resource_group)
+    provider_service.delete_associated_resources(name, resource_group)
     update_attributes!(:raw_power_state => "Deleting")
   end
 end


### PR DESCRIPTION
Delete the associated resources (NIC, IP, VHD, .status) when deleting a VM. For more details on what exactly is deleted please read the method [comments](https://github.com/ManageIQ/azure-armrest/blob/master/lib/azure/armrest/virtual_machine_service.rb#L124:#L141).

Note - ManageIQ domain retirement state machine default behavior will only retire a VM (and its components) that either:
1. was created by ManageIQ, 
2. tagged with lifecycle/retire_full. 




https://bugzilla.redhat.com/show_bug.cgi?id=1348718