### PR TITLE
Use debug instead of info to log filtered events

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -22,7 +22,7 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
 
   def process_event(event)
     if filtered?(event)
-      _log.info "#{log_prefix} Skipping filtered Azure event #{parse_event_type(event)} for #{event["resourceId"]}"
+      _log.debug "#{log_prefix} Skipping filtered Azure event #{parse_event_type(event)} for #{event["resourceId"]}"
     else
       _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{event["resourceId"]}"
       EmsEvent.add_queue('add_azure', @cfg[:ems_id], event)


### PR DESCRIPTION
When we filter out an Azure event e.g. the ```storageAccounts_listKeys``` events or those from the Classic Providers, we write some logging to file. This is set to ***info*** logging today, and given the volume of filtered events, it clutters the log file. This PR changes this to ***debug*** to reduce the volume of logging written.