### PR TITLE
Ignore config/secrets.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@
 /config/settings.local.yml
 /config/settings/*.local.yml
 /config/environments/*.local.yml
+/config/secrets.yml
 
 /spec/manageiq


### PR DESCRIPTION
This mirrors the original Rails repo so we can store our own credentials in config/secrets.yml. This is used mostly for when we need to regenerate VCR cassettes.