### PR TITLE
Delete all resources when deleting an Azure stack

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
@@ -44,7 +44,7 @@ class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ManageIQ::P
 
   def raw_delete_stack
     ext_management_system.with_provider_connection do |configure|
-      Azure::Armrest::TemplateDeploymentService.new(configure).delete(name, resource_group)
+      Azure::Armrest::TemplateDeploymentService.new(configure).delete_associated_resources(name, resource_group)
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -58,12 +58,12 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
 
     describe "#delete_stack" do
       it 'updates the stack' do
-        expect(orchestration_service).to receive(:delete)
+        expect(orchestration_service).to receive(:delete_associated_resources)
         subject.delete_stack
       end
 
       it 'catches errors from provider' do
-        expect(orchestration_service).to receive(:delete).and_raise('bad request')
+        expect(orchestration_service).to receive(:delete_associated_resources).and_raise('bad request')
         expect { subject.delete_stack }.to raise_error(MiqException::MiqOrchestrationDeleteError)
       end
     end


### PR DESCRIPTION
Azure API by default does not delete associated resources of a stack. In `azure-armrest` we made it possible to delete all associated resources together with a deployment.

We now make this default behavior for upstream, but for previous versions we should make it only optional in order not to surprise existing users. Therefore this change should not be auto back ported.

@djberg96 please review.