### PR TITLE
Return the available Floating IPs in Azure.

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager.rb
+++ b/app/models/manageiq/providers/azure/network_manager.rb
@@ -17,6 +17,9 @@ class ManageIQ::Providers::Azure::NetworkManager < ManageIQ::Providers::NetworkM
 
   include ManageIQ::Providers::Azure::ManagerMixin
 
+  has_many :floating_ips, :foreign_key => :ems_id, :dependent => :destroy,
+           :class_name => ManageIQ::Providers::Azure::NetworkManager::FloatingIp
+
   # Auth and endpoints delegations, editing of this type of manager must be disabled
   delegate :authentication_check,
            :authentication_status,

--- a/app/models/manageiq/providers/azure/network_manager/floating_ip.rb
+++ b/app/models/manageiq/providers/azure/network_manager/floating_ip.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Azure::NetworkManager::FloatingIp < ::FloatingIp
+  def self.available
+    joins(:network_port).where("network_ports.device_id" => nil) + where(:network_port_id => nil)
+  end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -53,6 +53,34 @@ describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
         end
       end
     end
+
+    context "floating ips" do
+      before do
+        FactoryGirl.create(:network_port_azure, :id => 1, :device_id => nil)
+        ems.floating_ips << FactoryGirl.create(
+          :floating_ip_azure,
+          :ext_management_system => ems.network_manager,
+          :network_port_id       => 1
+        )
+
+        FactoryGirl.create(:network_port_azure, :id => 2, :device_id => 1)
+        ems.floating_ips << FactoryGirl.create(
+          :floating_ip_azure,
+          :ext_management_system => ems.network_manager,
+          :network_port_id       => 2
+        )
+
+        ems.floating_ips << FactoryGirl.create(
+          :floating_ip_azure,
+          :ext_management_system => ems.network_manager,
+          :network_port_id       => nil
+        )
+      end
+
+      it "allowed_floating_ips" do
+        expect(workflow.allowed_floating_ip_addresses.length).to eq(2)
+      end
+    end
   end
 
   context "with applied tags" do


### PR DESCRIPTION
PR [#12300](ManageIQ/manageiq#12300) changed the Floating::IP available method to return floating IPs not associated with either a VM or a NIC. The FloatingIp::available method is used in cloud instance provisioning to display a list of available floating IPs that can be re-used. This change inadvertently affected the Azure provider integration where a FloatingIp is considered available when it is associated with a NIC as long as that NIC is not attached to another device, which can occur when a VM is deleted and its NIC and IP remain orphaned.

This PR is for an Azure specific way to determine available Floating Ips.

https://bugzilla.redhat.com/show_bug.cgi?id=1380728
