### PR TITLE
Fix issue where EmsEvent.add_azure method no longer exists

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -25,7 +25,8 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
       _log.debug "#{log_prefix} Skipping filtered Azure event #{parse_event_type(event)} for #{event["resourceId"]}"
     else
       _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{event["resourceId"]}"
-      EmsEvent.add_queue('add_azure', @cfg[:ems_id], event)
+      event_hash = ManageIQ::Providers::Azure::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+      EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
     end
   end
 


### PR DESCRIPTION
Fixes issue caused by https://github.com/ManageIQ/manageiq/pull/13714

Note that this PR does not have any specs, and I'd like to discuss adding them, but in a way that makes sense.