### PR TITLE
Add update task, and automatically update before running specs.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,12 @@ namespace :spec do
   task :setup => 'app:test:providers:azure:setup'
 end
 
+desc "Update your local ManageIQ repository"
+task :update do
+  sh "bin/update" unless ENV['CI']
+end
+
 desc "Run all azure specs"
-task :spec => 'app:test:providers:azure'
+task :spec => [:update, 'app:test:providers:azure']
 
 task :default => :spec


### PR DESCRIPTION
This PR adds an `:update` task, which is just a wrapper for "bin/update".

Also, since it's easy to forget to update the core repo before running specs, which can lead to unexpected errors, the :update task was added as a prerequisite to the `:spec` task.