### PR TITLE
Give orchestration stack double a name

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -3,7 +3,7 @@ require 'azure-armrest'
 describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
   let(:ems) { FactoryGirl.create(:ems_azure_with_authentication) }
   let(:template) { FactoryGirl.create(:orchestration_template_azure_with_content) }
-  let(:orchestration_service) { double }
+  let(:orchestration_service) { double("orchestration service") }
   let(:the_raw_stack) do
     Azure::Armrest::TemplateDeployment.new(
       'id'         => 'one_id',


### PR DESCRIPTION
This is a cherry-pick from the core repo.

See https://github.com/ManageIQ/manageiq/pull/13770