### PR TITLE
Disable metrics and events in unsupported regions

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher.rb
@@ -1,3 +1,14 @@
 class ManageIQ::Providers::Azure::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
   require_nested :Runner
+
+  # Override the superclass method in order to disable event collection for
+  # providers that do not support it.
+  #
+  def self.all_valid_ems_in_zone
+    super.select do |ems|
+      ems.supports_timeline?.tap do |available|
+        _log.info(ems.unsupported_reason(:timeline) + _(" [#{ems.provider_region}]")) unless available
+      end
+    end
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -74,14 +74,7 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
   }.freeze
 
   def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
-    ems = target.ext_management_system
-
-    raise "No EMS defined" if ems.nil?
-
-    unless ems.insights?
-      _log.info("Metrics not supported for region: " + _("[#{ems.provider_region}]"))
-      return
-    end
+    raise "No EMS defined" if target.ext_management_system.nil?
 
     log_header = "[#{interval_name}] for: [#{target.class.name}], [#{target.id}], [#{target.name}]"
 
@@ -190,6 +183,13 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
   end
 
   def get_counters(metrics_conn)
+    ems = target.ext_management_system
+
+    unless ems.insights?
+      _log.info("Metrics not supported for region: " + _("[#{ems.provider_region}]"))
+      return []
+    end
+
     begin
       counters, _timings = Benchmark.realtime_block(:capture_counters) do
         metrics_conn

--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -74,7 +74,14 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
   }.freeze
 
   def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
-    raise "No EMS defined" if target.ext_management_system.nil?
+    ems = target.ext_management_system
+
+    raise "No EMS defined" if ems.nil?
+
+    unless ems.insights?
+      _log.info("Metrics not supported for region: " + _("[#{ems.provider_region}]"))
+      return
+    end
 
     log_header = "[#{interval_name}] for: [#{target.class.name}], [#{target.id}], [#{target.name}]"
 
@@ -194,6 +201,7 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
       _log.log_backtrace(err)
       raise
     end
+
     counters
   end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb
@@ -1,0 +1,24 @@
+describe ManageIQ::Providers::Azure::CloudManager::EventCatcher do
+  context "valid ems" do
+    let(:unsupported_reason) { "Timeline events not supported for this region" }
+
+    before do
+      @ems = FactoryGirl.create(:ems_azure)
+      allow(@ems).to receive(:authentication_status_ok?).and_return(true)
+      allow(described_class).to receive(:all_ems_in_zone).and_return([@ems])
+    end
+
+    it "returns a valid ems for zone if timeline events are supported" do
+      allow(@ems).to receive(:supports_timeline?).and_return(true)
+      expect($log).not_to receive(:info).with(/#{unsupported_reason}/)
+      expect(described_class.all_valid_ems_in_zone).to include(@ems)
+    end
+
+    it "returns an empty list for zone if timeline events are not supported" do
+      allow(@ems).to receive(:supports_timeline?).and_return(false)
+      allow(@ems).to receive(:unsupported_reason).and_return(unsupported_reason)
+      expect($log).to receive(:info).with(/#{unsupported_reason}/)
+      expect(described_class.all_valid_ems_in_zone).not_to include(@ems)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -177,6 +177,42 @@ describe ManageIQ::Providers::Azure::CloudManager do
       assert_region(emses[2], "Azure-westus")
     end
 
+    context "supports features" do
+      before(:each) do
+        name = 'Azure-CentralUS'
+        region = 'centralus'
+        @ems = FactoryGirl.create(:ems_azure, :name => name, :provider_region => region)
+      end
+
+      it "supports regions" do
+        expect(@ems).to respond_to(:supports_regions?)
+        expect(@ems.supports_regions?).to eql(true)
+      end
+
+      it "supports discovery" do
+        expect(@ems).to respond_to(:supports_discovery?)
+        expect(@ems.supports_discovery?).to eql(true)
+      end
+
+      it "supports provisioning" do
+        expect(@ems).to respond_to(:supports_provisioning?)
+        expect(@ems.supports_provisioning?).to eql(true)
+      end
+
+      it "supports timeline events if insights is registered" do
+        allow(@ems).to receive(:insights?).and_return(true)
+        expect(@ems).to respond_to(:supports_timeline?)
+        expect(@ems.supports_provisioning?).to eql(true)
+      end
+
+      it "does not support timeline events if insights not registered" do
+        allow(@ems).to receive(:insights?).and_return(false)
+        expect(@ems).to respond_to(:supports_timeline?)
+        expect(@ems.supports_timeline?).to eql(false)
+        expect(@ems.unsupported_reason(:timeline)).to eql('Timeline not supported for this region')
+      end
+    end
+
     context "with records from a different account" do
       it "with the same name" do |example|
         FactoryGirl.create(:ems_azure_with_authentication, :name => "Azure-westus", :provider_region => "westus")


### PR DESCRIPTION
This PR uses the SupportsFeatureMixin and the most recent azure-armrest gem to disable metrics and events collection in regions that are not supported.

Note that this requires the addition of `:metrics` to the support matrix. See https://github.com/ManageIQ/manageiq/pull/13381

~~You will also have to update gems-pending-config to point to azure-armrest 0.6.0.~~