### PR TITLE
Check for offer attribute when checking for Guest OS

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -268,11 +268,14 @@ module ManageIQ::Providers
         }
       end
 
-      # find both OS and SKU if possible, otherwise just the OS type.
+      # Find both OS and SKU if possible, otherwise just the OS type.
       def guest_os(instance)
         image_reference = instance.properties.storage_profile.try(:image_reference)
-        return instance.properties.storage_profile.os_disk.os_type unless image_reference
-        "#{image_reference.offer} #{image_reference.sku.tr('-', ' ')}"
+        if image_reference && image_reference.try(:offer)
+          "#{image_reference.offer} #{image_reference.sku.tr('-', ' ')}"
+        else
+          instance.properties.storage_profile.os_disk.os_type
+        end
       end
 
       def populate_hardware_hash_with_disks(hardware_disks_array, instance)


### PR DESCRIPTION
Apparently it's possible to have an image reference property on a VM without an offer attribute. This addresses that.

https://bugzilla.redhat.com/show_bug.cgi?id=1422635