### PR TITLE
Account for managed disks

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -254,7 +254,7 @@ module ManageIQ::Providers
         data_disks.each do |disk|
           disk_size      = disk.respond_to?(:disk_size_gb) ? disk.disk_size_gb * 1.gigabyte : 0
           disk_name      = disk.name
-          disk_location  = disk.vhd.uri
+          disk_location  = disk.try(:vhd).try(:uri)
 
           add_instance_disk(hardware_disks_array, disk_size, disk_name, disk_location)
         end
@@ -299,8 +299,9 @@ module ManageIQ::Providers
 
         os_disk = instance.properties.storage_profile.os_disk
         sz      = series[:root_disk_size]
+        vhd_loc = os_disk.try(:vhd).try(:uri)
 
-        add_instance_disk(hardware_hash[:disks], sz, os_disk.name, os_disk.vhd.uri) unless sz.zero?
+        add_instance_disk(hardware_hash[:disks], sz, os_disk.name, vhd_loc) unless sz.zero?
 
         # No data availbale on swap disk? Called temp or resource disk.
       end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1431361

Addresses the possibility that a VM does not have a `:vhd` attribute. Azure has been moving away from individual VHD's on storage accounts and moving towards managed disks. If a VM uses a managed disk, then that information will not be directly available.

https://docs.microsoft.com/en-us/azure/storage/storage-managed-disks-overview

We may be able to get this information in the future, but it will require upgrading the azure-armrest gem. For now, just ignore the disk location if it isn't found.

