### PR TITLE
Add backtrace info to verify_credentials failure

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -19,7 +19,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
   rescue MiqException::MiqInvalidCredentialsError
     raise # Raise before falling into catch-all block below
   rescue => err
-    _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+    _log.error("Error Class=#{err.class.name}, Message=#{err.message}, Backtrace=#{err.backtrace}")
     raise MiqException::MiqInvalidCredentialsError, _("Unexpected response returned from system: #{err.message}")
   else
     conf


### PR DESCRIPTION
There's no reason not to include backtrace information if `verify_credentials fails`. Let's include it.