### PR TITLE
Warn and bail on timeout when collecting metrics

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -196,6 +196,9 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
           .list('Microsoft.Compute', 'virtualMachines', target.name, target.resource_group)
           .select { |m| m.name.value.in?(COUNTER_NAMES) }
       end
+    rescue ::Azure::Armrest::RequestTimeoutException # Problem on Azure side
+      _log.warn("Timeout attempting to collect metrics definitions for: #{target.name}/#{target.resource_group}. Skipping.")
+      counters = []
     rescue Exception => err
       _log.error("Unhandled exception during counter collection: #{target.name}/#{target.resource_group}")
       _log.log_backtrace(err)


### PR DESCRIPTION
If we get a TimeoutException from Azure when gathering metrics information, just log a warning and return an empty result instead of raising an exception.

While searching offered precious little information, this appears to be an issue on the Azure side.  All we're doing is this:

    metrics_conn.list('Microsoft.Compute', 'virtualMachines', name, resource_group)

And that's not even collecting metrics information itself, just the metrics definitions.

IMO this is only possible if there's a problem with the storage account that stores the diagnostic for the VM. I think it can also be caused by moving the resources from one resource group to another, though that's speculation. In either case, there's little we can do about it on our end except to log it and move on.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1436393