### PR TITLE
Ensure managers change zone and provider region with CloudManager

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -32,6 +32,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   end
 
   before_create :ensure_managers
+  before_update :ensure_managers_zone_and_provider_region
 
   # If the Microsoft.Insights Azure provider is not registered, then neither
   # events nor metrics are supported for that EMS.

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -25,6 +25,25 @@ describe ManageIQ::Providers::Azure::CloudManager do
     expect(ExtManagementSystem.count).to eq(0)
   end
 
+  it "moves the network_manager to the same zone and provider region as the cloud_manager" do
+    zone1 = FactoryGirl.create(:zone)
+    zone2 = FactoryGirl.create(:zone)
+
+    ems = FactoryGirl.create(:ems_azure, :zone => zone1, :provider_region => "region1")
+    expect(ems.network_manager.zone).to eq zone1
+    expect(ems.network_manager.zone_id).to eq zone1.id
+    expect(ems.network_manager.provider_region).to eq "region1"
+
+    ems.zone = zone2
+    ems.provider_region = "region2"
+    ems.save!
+    ems.reload
+
+    expect(ems.network_manager.zone).to eq zone2
+    expect(ems.network_manager.zone_id).to eq zone2.id
+    expect(ems.network_manager.provider_region).to eq "region2"
+  end
+
   context "#connectivity" do
     before do
       @e = FactoryGirl.create(:ems_azure)


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/14741

Ensure managers change zone and provider region with CloudManager

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1440327