### PR TITLE
Update azure-armrest dependency to 0.7.1

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config.lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "=0.7.0"
+  s.add_dependency "azure-armrest", "=0.7.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This brings us up to azure-armrest 0.7.1 which has a bug fix, and also updates the nokogiri dependency because of a CVE.