### PR TITLE
Update the azure-armrest gem dependency

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config.lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "=0.7.0"
+  s.add_dependency "azure-armrest", "=0.7.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This solves some nokogiri dependency resolution issues in other repos/gems.

See:
https://github.com/ManageIQ/manageiq-gems-pending/pull/117
https://github.com/ManageIQ/azure-armrest/pull/272

Ping @djberg96 