### PR TITLE
Make azure-armrest dependency less pessimistic

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config.lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "=0.7.1"
+  s.add_dependency "azure-armrest", "~>0.7.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This lines up with how the dependencies for gems-pending is setup, and is generally easier to deal with.