### PR TITLE
Fixes the definition of spec.files in gemspec

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "Azure Provider for ManageIQ"
   s.licenses    = ["Apache-2.0"]
 
-  s.files = Dir["{app,config.lib}/**/*"]
+  s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency "azure-armrest", "~>0.7.2"
 


### PR DESCRIPTION
With `Dir["{app,config.lib}"]`, that only tries to find two dirs: `app`, and `config.lib` (this one isn't real, obviously).

With the fix to `Dir["{app,config.lib}"]`, it then will search through the app, config, and lib directories properly