### PR TITLE
Create resource group association for instances and managed images

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -229,6 +229,8 @@ module ManageIQ::Providers
         # unified under the NetworkManager
         hardware_network_info = get_hardware_network_info(instance)
 
+        rg_ems_ref = get_resource_group_ems_ref(instance)
+
         new_result = {
           :type                => 'ManageIQ::Providers::Azure::CloudManager::Vm',
           :uid_ems             => uid,
@@ -241,6 +243,7 @@ module ManageIQ::Providers
           :location            => instance.location,
           :orchestration_stack => @data_index.fetch_path(:orchestration_stacks, @resource_to_stack[uid]),
           :availability_zone   => @data_index.fetch_path(:availability_zones, 'default'),
+          :resource_group      => @data_index.fetch_path(:resource_groups, rg_ems_ref),
           :hardware            => {
             :disks    => [], # Filled in later conditionally on flavor
             :networks => hardware_network_info
@@ -507,6 +510,7 @@ module ManageIQ::Providers
         uid = image.id.downcase
 
         os = image.properties.storage_profile.try(:os_disk).try(:os_type) || 'unknown'
+        rg_ems_ref = get_resource_group_ems_ref(image)
 
         new_result = {
           :type               => ManageIQ::Providers::Azure::CloudManager::Template.name,
@@ -520,6 +524,7 @@ module ManageIQ::Providers
           :template           => true,
           :publicly_available => false,
           :operating_system   => process_os(image),
+          :resource_group     => @data_index.fetch_path(:resource_groups, rg_ems_ref),
           :hardware           => {
             :bitness  => 64,
             :guest_os => OperatingSystem.normalize_os_name(os)
@@ -555,6 +560,7 @@ module ManageIQ::Providers
 
       def parse_image(image)
         uid = image.uri
+
         new_result = {
           :type               => ManageIQ::Providers::Azure::CloudManager::Template.name,
           :uid_ems            => uid,
@@ -571,6 +577,7 @@ module ManageIQ::Providers
             :guest_os => image.operating_system
           }
         }
+
         return uid, new_result
       end
 

--- a/app/models/manageiq/providers/azure/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm.rb
@@ -7,11 +7,6 @@ class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudM
     ::Azure::Armrest::VirtualMachineService.new(connection)
   end
 
-  # The resource group is stored as part of the uid_ems. This splits it out.
-  def resource_group
-    uid_ems.split('\\')[1]
-  end
-
   #
   # Relationship methods
   #

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -44,6 +44,12 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     end
   end
 
+  # Given an object, return the matching ems_ref for its resource group.
+  #
+  def get_resource_group_ems_ref(object)
+    "/subscriptions/#{object.subscription_id}/resourceGroups/#{object.resource_group.downcase}"
+  end
+
   # TODO(lsmola) NetworkManager, move below methods under NetworkManager, once it is not needed in Cloudmanager
   def get_vm_nics(instance)
     nic_ids = instance.properties.network_profile.network_interfaces.collect(&:id)

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -100,6 +100,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       assert_specific_load_balancer_health_checks
       assert_specific_vm_with_managed_disk
       assert_specific_managed_disk
+      assert_specific_resource_group
     end
   end
 
@@ -481,6 +482,17 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
 
     expect(disk.location).to be_nil
     expect(disk.size).to eql(1023.megabyte)
+  end
+
+  def assert_specific_resource_group
+    vm_managed   = Vm.find_by(:name => @managed_vm)
+    vm_unmanaged = Vm.find_by(:name => @device_name)
+
+    managed_group = ResourceGroup.find_by(:name => 'miq-azure-test4')
+    unmanaged_group = ResourceGroup.find_by(:name => 'miq-azure-test1')
+
+    expect(vm_managed.resource_group).to eql(managed_group)
+    expect(vm_unmanaged.resource_group).to eql(unmanaged_group)
   end
 
   def assert_specific_vm_powered_off

--- a/spec/models/manageiq/providers/azure/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/vm_spec.rb
@@ -6,14 +6,6 @@ describe ManageIQ::Providers::Azure::CloudManager::Vm do
   let(:power_state_off) { "VM deallocated" }
   let(:power_state_suspended) { "VM stopping" }
 
-  context "resource_group" do
-    it "defines a resource_group method that returns the expected value based on uid_ems" do
-      vm.uid_ems = "aaa\\bbb\\ccc\\ddd"
-      expect(vm).to respond_to(:resource_group)
-      expect(vm.resource_group).to eq("bbb")
-    end
-  end
-
   context "#is_available?" do
     context("with :start") do
       let(:state) { :start }

--- a/spec/models/manageiq/providers/azure/refresh_helper_methods_spec.rb
+++ b/spec/models/manageiq/providers/azure/refresh_helper_methods_spec.rb
@@ -12,6 +12,16 @@ describe ManageIQ::Providers::Azure::RefreshHelperMethods do
   let(:virtual_machine_eastus) { Azure::Armrest::VirtualMachine.new(:name => "foo", :location => "eastus") }
   let(:virtual_machine_southindia) { Azure::Armrest::VirtualMachine.new(:name => "bar", :location => "SouthIndia") }
 
+  context "get_resource_group_ems_ref" do
+    it "returns the expected value" do
+      virtual_machine_eastus.subscription_id = "abc123"
+      virtual_machine_eastus.resource_group = "Test_Group"
+
+      expected = "/subscriptions/abc123/resourceGroups/test_group"
+      expect(@ems_azure.get_resource_group_ems_ref(virtual_machine_eastus)).to eql(expected)
+    end
+  end
+
   context "gather_data_for_region" do
     it "requires a service name" do
       expect { @ems_azure.gather_data_for_this_region }.to raise_error(ArgumentError)


### PR DESCRIPTION
At the moment we collect resource group information, but don't actually create the appropriate association between a resource and its resource group. This PR attempts to implement that, starting with VM instances and managed images.

Note that this will require some modifications to the core repo before it actually works properly. Without them this does nothing of note, though it doesn't cause any breakage.

Addresses https://github.com/ManageIQ/manageiq-providers-azure/issues/69

Working in conjunction with https://github.com/ManageIQ/manageiq/pull/15187