### PR TITLE
Provisioning - First and Last names are not required.

### DIFF
--- a/content/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name: 
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager: 
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name: 
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail: 


### PR DESCRIPTION
Fields are not being populated during life-cycle provisioning so
There is no reason to make them required.

This eliminates 2 required fields when provisioning.

https://bugzilla.redhat.com/show_bug.cgi?id=1454351

I did this previously in ManageIQ,  see

https://github.com/ManageIQ/manageiq/pull/14694

@miq-bot add_label bug,