### PR TITLE
Upgrade armrest gem to 0.7.3

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.7.2"
+  s.add_dependency "azure-armrest", "~>0.7.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This bumps the azure-armrest dependency to 0.7.3, which added guards against ECONNREFUSED and TimeoutException for the StorageAccountService#get_private_images method.

https://bugzilla.redhat.com/show_bug.cgi?id=1456044