### PR TITLE
Use a simpler name for network ports

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
@@ -376,12 +376,12 @@ class ManageIQ::Providers::Azure::NetworkManager::RefreshParser
     uid = "#{load_balancer[:ems_ref]}/nic1"
 
     new_result = {
-      :device_ref    => load_balancer[:ems_ref],
-      :device        => load_balancer,
-      :ems_ref       => uid,
-      :name          => uid,
-      :status        => "Succeeded",
-      :type          => self.class.network_port_type,
+      :device_ref => load_balancer[:ems_ref],
+      :device     => load_balancer,
+      :ems_ref    => uid,
+      :name       => File.basename(load_balancer[:ems_ref]) + '/nic1',
+      :status     => "Succeeded",
+      :type       => self.class.network_port_type,
     }
 
     @data[:network_ports] << new_result
@@ -414,7 +414,7 @@ class ManageIQ::Providers::Azure::NetworkManager::RefreshParser
 
     new_result = {
       :type                       => self.class.network_port_type,
-      :name                       => uid,
+      :name                       => network_port.name,
       :ems_ref                    => uid,
       :status                     => network_port.properties.try(:provisioning_state),
       :mac_address                => network_port.properties.try(:mac_address),

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -709,30 +709,31 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
   end
 
   def assert_specific_nic_and_ip
-    nic_group  = 'miq-azure-test1' # EastUS
-    ip_group   = 'miq-azure-test4' # Also EastUS
+    nic_group = 'miq-azure-test1' # EastUS
+    ip_group  = 'miq-azure-test4' # Also EastUS
+    nic_name  = 'miqmismatch1'
 
-    nic_name = "/subscriptions/#{@subscription_id}/resourceGroups"\
+    ems_ref_nic = "/subscriptions/#{@subscription_id}/resourceGroups"\
                "/#{nic_group}/providers/Microsoft.Network"\
                "/networkInterfaces/miqmismatch1"
 
-    ems_ref = "/subscriptions/#{@subscription_id}/resourceGroups"\
+    ems_ref_ip = "/subscriptions/#{@subscription_id}/resourceGroups"\
                "/#{ip_group}/providers/Microsoft.Network"\
                "/publicIPAddresses/miqmismatch1"
 
-    @network_port = ManageIQ::Providers::Azure::NetworkManager::NetworkPort.where(:name => nic_name).first
-    @floating_ip  = ManageIQ::Providers::Azure::NetworkManager::FloatingIp.where(:ems_ref => ems_ref).first
+    @network_port = ManageIQ::Providers::Azure::NetworkManager::NetworkPort.where(:ems_ref => ems_ref_nic).first
+    @floating_ip  = ManageIQ::Providers::Azure::NetworkManager::FloatingIp.where(:ems_ref => ems_ref_ip).first
 
     expect(@network_port).to have_attributes(
       :status  => 'Succeeded',
       :name    => nic_name,
-      :ems_ref => nic_name, # Same
+      :ems_ref => ems_ref_nic
     )
 
     expect(@floating_ip).to have_attributes(
       :status  => 'Succeeded',
       :address => @mismatch_ip,
-      :ems_ref => ems_ref,
+      :ems_ref => ems_ref_ip,
     )
 
     expect(@network_port.device.id).to eql(@floating_ip.vm.id)


### PR DESCRIPTION
At the moment we're using the `ems_ref` as the network_port name for some resaon. This changes it to just use the actual name. This saves a lot of screen real estate and looks nicer:

<img width="814" alt="screen shot 2017-06-20 at 8 13 15 am" src="https://user-images.githubusercontent.com/78529/27337793-b13cf282-5590-11e7-8764-822f36be8cb7.png">

Underlying code should be unaffected since the record identifier (ems_ref) is unchanged.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1402855