### PR TITLE
Disable reset operation for VMs and add specs

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
@@ -6,6 +6,8 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations::Power
       unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
       unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
     end
+
+    supports_not :reset, :reason => "Hard reboot not supported on Azure"
   end
 
   def raw_suspend

--- a/spec/models/manageiq/providers/azure/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/vm_spec.rb
@@ -1,19 +1,20 @@
 describe ManageIQ::Providers::Azure::CloudManager::Vm do
-  context "#is_available?" do
-    let(:ems) { FactoryGirl.create(:ems_azure) }
-    let(:host) { FactoryGirl.create(:host, :ext_management_system => ems) }
-    let(:vm) { FactoryGirl.create(:vm_azure, :ext_management_system => ems, :host => host) }
+  let(:ems) { FactoryGirl.create(:ems_azure) }
+  let(:host) { FactoryGirl.create(:host, :ext_management_system => ems) }
+  let(:vm) { FactoryGirl.create(:vm_azure, :ext_management_system => ems, :host => host) }
+  let(:power_state_on)  { "VM running" }
+  let(:power_state_off) { "VM deallocated" }
+  let(:power_state_suspended) { "VM stopping" }
 
-    let(:power_state_on)  { "VM running" }
-    let(:power_state_off) { "VM deallocated" }
-    let(:power_state_suspended) { "VM stopping" }
-
+  context "resource_group" do
     it "defines a resource_group method that returns the expected value based on uid_ems" do
       vm.uid_ems = "aaa\\bbb\\ccc\\ddd"
       expect(vm).to respond_to(:resource_group)
       expect(vm.resource_group).to eq("bbb")
     end
+  end
 
+  context "#is_available?" do
     context("with :start") do
       let(:state) { :start }
       include_examples "Vm operation is available when not powered on"
@@ -22,6 +23,13 @@ describe ManageIQ::Providers::Azure::CloudManager::Vm do
     context("with :stop") do
       let(:state) { :stop }
       include_examples "Vm operation is available when powered on"
+    end
+  end
+
+  context "reset" do
+    it "does not support the reset operation" do
+      expect(vm.supports_reset?).to be_falsy
+      expect(vm.unsupported_reason(:reset)).to eql("Hard reboot not supported on Azure")
     end
   end
 end


### PR DESCRIPTION
Explicitly remove support for hard resets for Azure.

This partially addresses https://github.com/ManageIQ/manageiq/issues/9684. It will also require a change on the classic UI side, which is currently hard-coding a value for the instances view that is keeping the option around.

On a side note, I reorganized the specs a bit so that some of the variables were available to other contexts.