### PR TITLE
Handle possibility of network_port not having private_ip_address

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
@@ -390,7 +390,7 @@ class ManageIQ::Providers::Azure::NetworkManager::RefreshParser
 
   def parse_cloud_subnet_network_port(network_port)
     {
-      :address      => network_port.properties.private_ip_address,
+      :address      => network_port.properties.try(:private_ip_address),
       :cloud_subnet => @data_index.fetch_path(:cloud_subnets, network_port.properties.subnet.id)
     }
   end


### PR DESCRIPTION
Addresses an issue where not every IP configuration has a `private_ip_address` property. We already guard against this possibility in the cloud manager, but apparently missed it in the network manager.

Addresses https://github.com/ManageIQ/manageiq-providers-azure/issues/82
