### PR TITLE
Decrypt client keys in raw connect

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -38,7 +38,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
 
       ::Azure::Armrest::Configuration.new(
         :client_id       => client_id,
-        :client_key      => client_key,
+        :client_key      => MiqPassword.try_decrypt(client_key),
         :tenant_id       => azure_tenant_id,
         :subscription_id => subscription,
         :proxy           => proxy_uri,

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -1,5 +1,14 @@
 require 'azure-armrest'
 describe ManageIQ::Providers::Azure::CloudManager do
+  describe ".raw_connect" do
+    it "decrypts passwords" do
+      allow(::Azure::Armrest::Configuration).to receive(:new)
+
+      expect(MiqPassword).to receive(:try_decrypt).with("1234567890")
+      described_class.raw_connect("klmnopqrst", "1234567890", "abcdefghij", 'subscription', 'proxy_uri')
+    end
+  end
+
   it ".ems_type" do
     expect(described_class.ems_type).to eq('azure')
   end


### PR DESCRIPTION
Working on switching credential validation onto the queue using the class method raw_connect to be able to validate in different zones and remove the use of a temporary EMS. This will require passwords to be encrypted / decrypted in raw_connect.

More info: https://github.com/ManageIQ/manageiq-ui-classic/pull/1580