### PR TITLE
Fix VM password restrictions

### DIFF
--- a/content/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -360,8 +360,8 @@
         :root_password:
           :description: Password
           :required_method: :validate_regex
-          :required_regex: !ruby/regexp /[(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[\W\D].*?]{12,72}$/
-          :required_regex_fail_details: The password must be 12-72 characters, contain at least one lowercase English character, one uppercase English character, and one number.
+          :required_regex: !ruby/regexp /(?=.{12,72})((?=.*\d)(?=.*[a-z])(?=.*[A-Z])|(?=.*\d)(?=.*[a-zA-Z])(?=.*[\W_])|(?=.*[a-z])(?=.*[A-Z])(?=.*[\W_])).*/
+          :required_regex_fail_details: The password must be 12-72 characters, and have 3 of the following - one lowercase character, one uppercase character, one number and one special character.
           :required: true
           :display: :edit
           :data_type: :string


### PR DESCRIPTION
This fixes the VM password restrictions to match the actual Azure password restrictions for virtual machines. The rules are that the password must at least 12 characters long and match at least 3 of the following 4 conditions:

* Contain 1 lowercase character
* Contain 1 uppercase character
* Contain 1 number
* Contain 1 special character

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1454812