### PR TITLE
Security Groups array_integer data type

### DIFF
--- a/content/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -174,7 +174,7 @@
           :description: Security Groups
           :required: false
           :display: :edit
-          :data_type: :integer
+          :data_type: :array_integer
         :floating_ip_address:
           :values_from:
             :method: :allowed_floating_ip_addresses


### PR DESCRIPTION
Adding the `array_integer` datatype to allow arrays to be passed into the security groups dialog

Dependent on: https://github.com/ManageIQ/manageiq/pull/15409

https://bugzilla.redhat.com/show_bug.cgi?id=1466032