### PR TITLE
Fix find_destination_in_vmdb to use insensitive find azure machine name in vmdb

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -11,7 +11,7 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
 
   def find_destination_in_vmdb(vm_uid_hash)
     ems_ref = vm_uid_hash.values.join("\\")
-    ManageIQ::Providers::Azure::CloudManager::Vm.find_by(:ems_ref => ems_ref.downcase)
+    ManageIQ::Providers::Azure::CloudManager::Vm.find_by("lower(ems_ref) = ?", ems_ref.downcase)
   end
 
   def gather_storage_account_properties


### PR DESCRIPTION
this PR is parts of this closed PR https://github.com/ManageIQ/manageiq/issues/15530 but base on master

another parts is here https://github.com/ManageIQ/manageiq/pull/15546

-------------------------------------------------------------------------------------------------------------------------------------------
here is the description:
This PR is aim to fix azure machine can not be found in vmdb after deployment, which leads to exceed the 100 defaut retry time of executing the Automation Engine.

Let me explain you with some logs

evm.log example 1: 
```
[----] I, [2017-07-07T07:13:31.343135 #1903:1311130]  INFO -- : Q-task_id([miq_provision_474]) MIQ(ManageIQ::Providers::Azure::CloudManager::Provision#poll_destination_in_vmdb) Unable to find Vm [Zttestazurevm2] with ems_ref [{:subscription_id=>"888888888-88888-8888-8888-888888888842", :vm_resource_group=>"Default-Storage-JapanEast", :type=>"microsoft.compute/virtualmachines", :vm_name=>"Zttestazurevm2"}], will retry
```
however object in db:
```
irb(main):007:0> ManageIQ::Providers::Azure::CloudManager::Vm.where('ems_ref like ?', '%Zttestazurevm2%').first.ems_ref
=> "888888888-88888-8888-8888-888888888842\\default-storage-japaneast\\microsoft.compute/virtualmachines\\Zttestazurevm2"
```

analyse: my `vm_name` has uppercase in it and when we try to find in db, it become lower case and we we could not find it