### PR TITLE
Marketplace image support

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -51,7 +51,7 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
 
     # TODO: Ideally this would be a check against source.storage or source.disks
     if source.ems_ref =~ /.+:.+:.+:.+/
-      urn_keys = ['publisher', 'offer', 'sku', 'version']
+      urn_keys = %w[publisher offer sku version]
       image_reference = Hash[urn_keys.zip(source.ems_ref.split(':'))]
       os, target_uri, source_uri = nil
     elsif source.ems_ref.starts_with?('/subscriptions')

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -50,10 +50,16 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
     nic_id = associated_nic || create_nic
 
     # TODO: Ideally this would be a check against source.storage or source.disks
-    if source.ems_ref.starts_with?('/subscriptions')
+    if source.ems_ref =~ /.+:.+:.+:.+/
+      urn_keys = ['publisher', 'offer', 'sku', 'version']
+      image_reference = Hash[urn_keys.zip(source.ems_ref.split(':'))]
+      os, target_uri, source_uri = nil
+    elsif source.ems_ref.starts_with?('/subscriptions')
       os = source.operating_system.product_name
       target_uri, source_uri = nil
+      image_reference = { :id => source.ems_ref }
     else
+      image_reference = nil
       target_uri, source_uri, os = gather_storage_account_properties
     end
 
@@ -90,7 +96,7 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
     else
       # Default to a storage account type of "Standard_LRS" for managed images for now.
       cloud_options[:properties][:storageProfile][:osDisk][:managedDisk] = {:storageAccountType => 'Standard_LRS'}
-      cloud_options[:properties][:storageProfile][:imageReference] = {:id => source.ems_ref}
+      cloud_options[:properties][:storageProfile][:imageReference] = image_reference
     end
 
     cloud_options[:properties][:osProfile][:customData] = custom_data unless userdata_payload.nil?

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -51,7 +51,7 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
 
     # TODO: Ideally this would be a check against source.storage or source.disks
     if source.ems_ref =~ /.+:.+:.+:.+/
-      urn_keys = %w[publisher offer sku version]
+      urn_keys = %w(publisher offer sku version)
       image_reference = Hash[urn_keys.zip(source.ems_ref.split(':'))]
       os, target_uri, source_uri = nil
     elsif source.ems_ref.starts_with?('/subscriptions')

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -548,7 +548,7 @@ module ManageIQ::Providers
               :bitness  => 64,
               :guest_os => 'unknown'
             }
-        }
+          }
 
         return uid, new_result
       end

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -532,7 +532,8 @@ module ManageIQ::Providers
       def parse_market_image(image)
         uid = image.id
 
-        new_result = {
+        new_result =
+          {
             :type               => ManageIQ::Providers::Azure::CloudManager::Template.name,
             :uid_ems            => uid,
             :ems_ref            => uid,
@@ -544,8 +545,8 @@ module ManageIQ::Providers
             :template           => true,
             :publicly_available => true,
             :hardware           => {
-                :bitness  => 64,
-                :guest_os => 'unknown'
+              :bitness  => 64,
+              :guest_os => 'unknown'
             }
         }
 

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -88,6 +88,12 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     end
   end
 
+  def virtual_machine_image_service(config, options = {})
+    ::Azure::Armrest::VirtualMachineImageService.new(config, options).tap do |service|
+      service.api_version = Settings.ems.ems_azure.api_versions.managed_image.to_s
+    end
+  end
+
   def network_interface_service(config)
     ::Azure::Armrest::Network::NetworkInterfaceService.new(config).tap do |service|
       service.api_version = Settings.ems.ems_azure.api_versions.network_interface.to_s

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,6 +30,8 @@
     :additional_regions: {}
 :ems_refresh:
   :azure:
+    # If get_market_images is enabled with no filters, all public images will be added
+    # This will cause performance issues during refresh and at places in the UI where images are listed
     :get_market_images: false
     :market_image_urns:
       - MicrosoftWindowsServer:WindowsServer-HUB:2016-Datacenter-HUB:2016.127.20170630

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,14 @@
             - virtualMachines_restart_EndRequest
     :disabled_regions: []
     :additional_regions: {}
+:ems_refresh:
+  :azure:
+    :get_market_images: false
+    :market_image_urns:
+      - MicrosoftWindowsServer:WindowsServer-HUB:2016-Datacenter-HUB:2016.127.20170630
+      - OpenLogic:CentOS:7.3:7.3.20170517
+      - RedHat:RHEL:7.3:7.3.2017051117
+
 :http_proxy:
   :azure:
     :host:


### PR DESCRIPTION
This allows ```refresh_parser``` to fetch marketplace images, filtered by URNs supplied in settings.yml, and handles provisioning of instances from said images by matching against the format of a marketplace URN in ```prepare_for_clone_task```