### PR TITLE
Upgrade azure-armrest gem to 0.8.0

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.7.3"
+  s.add_dependency "azure-armrest", "~>0.8.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This updates the azure-armrest gem to 0.8.0. The major version bump was because some return types were changed in the Storage model for a couple methods. However, the methods that were altered are not currently used in ManageIQ.

In addition to other updates, this contains the `VirtualMachineImage#list_all` method, which we need for marketplace image support: https://github.com/ManageIQ/manageiq-providers-azure/pull/95