### PR TITLE
Ignore case when gathering data for region

### DIFF
--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -24,7 +24,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
   def gather_data_for_this_region(arm_service, method_name = 'list_all')
     if method_name.to_s == 'list_all'
       arm_service.send(method_name).select do |resource|
-        resource.try(:location) == @ems.provider_region
+        resource.try(:location).try(:casecmp, @ems.provider_region).zero?
       end.flatten
     elsif method_name.to_s == 'list_all_private_images' # requires special handling
       arm_service.send(method_name, :location => @ems.provider_region)
@@ -32,7 +32,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
       resource_groups.collect do |resource_group|
         arm_service.send(method_name, resource_group.name).select do |resource|
           location = resource.respond_to?(:location) ? resource.location : resource_group.location
-          location == @ems.provider_region
+          location.casecmp(@ems.provider_region).zero?
         end
       end.flatten
     end
@@ -40,7 +40,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
 
   def resource_groups
     @resource_groups ||= @rgs.list.select do |resource_group|
-      resource_group.location == @ems.provider_region
+      resource_group.location.casecmp(@ems.provider_region).zero?
     end
   end
 

--- a/spec/models/manageiq/providers/azure/refresh_helper_methods_spec.rb
+++ b/spec/models/manageiq/providers/azure/refresh_helper_methods_spec.rb
@@ -1,0 +1,41 @@
+require 'azure-armrest'
+
+describe ManageIQ::Providers::Azure::RefreshHelperMethods do
+  before do
+    @ems_azure = FactoryGirl.create(:ems_azure, :name => 'test', :provider_region => 'eastus')
+    @ems_azure.extend(described_class)
+    @ems_azure.instance_variable_set(:@ems, @ems_azure)
+    allow(Azure::Armrest::VirtualMachineService).to receive(:new).and_return(virtual_machine_service)
+  end
+
+  let(:virtual_machine_service) { double }
+  let(:virtual_machine_eastus) { Azure::Armrest::VirtualMachine.new(:name => "foo", :location => "eastus") }
+  let(:virtual_machine_southindia) { Azure::Armrest::VirtualMachine.new(:name => "bar", :location => "SouthIndia") }
+
+  context "gather_data_for_region" do
+    it "requires a service name" do
+      expect { @ems_azure.gather_data_for_this_region }.to raise_error(ArgumentError)
+    end
+
+    it "accepts an optional method name" do
+      allow(virtual_machine_service).to receive(:list_all).and_return([])
+      expect(@ems_azure.gather_data_for_this_region(virtual_machine_service, 'list_all')).to eql([])
+    end
+
+    it "returns the expected results for matching location" do
+      allow(virtual_machine_service).to receive(:list_all).and_return([virtual_machine_eastus])
+      expect(@ems_azure.gather_data_for_this_region(virtual_machine_service, 'list_all')).to eql([virtual_machine_eastus])
+    end
+
+    it "returns the expected results for non-matching location" do
+      allow(virtual_machine_service).to receive(:list_all).and_return([virtual_machine_southindia])
+      expect(@ems_azure.gather_data_for_this_region(virtual_machine_service, 'list_all')).to eql([])
+    end
+
+    it "ignores case when searching for matching locations" do
+      @ems_azure.provider_region = 'southindia'
+      allow(virtual_machine_service).to receive(:list_all).and_return([virtual_machine_southindia])
+      expect(@ems_azure.gather_data_for_this_region(virtual_machine_service, 'list_all')).to eql([virtual_machine_southindia])
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses what I consider a bug in the Azure REST API. The location for any given Azure resource is *supposed* to be lowercase, but in at least one case it's not. This PR modifies our data gathering method to ignore case where possible.

Specifically, virtual machines within any India region are mixed case, and that causes our refresh parser to miss them. Note that other resources within an India region have the location set as expected.

~~~WIP for now as I would like to add some specs.~~~

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1473619