### PR TITLE
Updated metric names for Azure metrics

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -2,12 +2,21 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
   INTERVAL_1_MINUTE = "PT1M".freeze
 
   # Linux, Windows counters
-  CPU_METERS     = ["\\Processor(_Total)\\% Processor Time", "\\Processor\\PercentProcessorTime"].freeze
+  CPU_METERS     = ["\\Processor Information(_Total)\\% Processor Time",
+                    "\\Processor(_Total)\\% Processor Time",
+                    "\\Processor\\PercentProcessorTime"].freeze
+
   NETWORK_METERS = ["\\NetworkInterface\\BytesTotal"].freeze # Linux (No windows counter available)
-  MEMORY_METERS  = ["\\Memory\\PercentUsedMemory", "\\Memory\\% Committed Bytes In Use"].freeze
+
+  MEMORY_METERS  = ["\\Memory\\PercentUsedMemory",
+                    "\\Memory\\% Committed Bytes In Use",
+                    "\\Memory\\Committed Bytes"].freeze
+
   DISK_METERS    = ["\\PhysicalDisk\\BytesPerSecond",
                     "\\PhysicalDisk(_Total)\\Disk Read Bytes/sec", # Windows
-                    "\\PhysicalDisk(_Total)\\Disk Write Bytes/sec"].freeze # Windows
+                    "\\PhysicalDisk(_Total)\\Disk Write Bytes/sec",
+                    "\\LogicalDisk(_Total)\\Disk Read Bytes/sec",
+                    "\\LogicalDisk(_Total)\\Disk Write Bytes/sec"].freeze # Windows
 
   COUNTER_INFO = [
     {


### PR DESCRIPTION
It appears that the Azure metrics names for CPU, Disk, Memory and Network have slightly changed for most, but not all, VMs eg:
`\\Processor(_Total)\\% Processor Time` has evolved to `\\Processor Information(_Total)\\% Processor Time`

This PR adds these new metric names while keeping the original version that some VMs seem to still respond to.

I am going to keep this a WIP while I finish writing specs.


https://bugzilla.redhat.com/show_bug.cgi?id=1476756