### PR TITLE
Add Snapshot Code for Azure Managed Disks

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -126,9 +126,11 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
                      :properties => {
                        :creationData => {
                          :createOption     => "Copy",
-                         :sourceResourceId => os_disk.managed_disk.id } } }
+                         :sourceResourceId => os_disk.managed_disk.id
+                       }
+                     } }
     snap_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
-    _log.debug ("vm=[#{vm.name}] creating SSA snapshot #{snap_name}")
+    _log.debug("vm=[#{vm.name}] creating SSA snapshot #{snap_name}")
     begin
       snap_svc.get(snap_name, vm.resource_group)
     rescue ::Azure::Armrest::NotFoundException, ::Azure::Armrest::ResourceNotFoundException => err
@@ -136,12 +138,12 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
         snap_svc.create(snap_name, vm.resource_group, snap_options)
         return snap_name
       rescue => err
-        _log.error ("vm=[#{vm.name}], error: #{err}")
+        _log.error("vm=[#{vm.name}], error: #{err}")
         _log.debug { err.backtrace.join("\n") }
         raise "Error #{err} creating SSA Snapshot #{snap_name}"
       end
     end
-    _log.error ("SSA Snapshot #{snap_name} already exists.")
+    _log.error("SSA Snapshot #{snap_name} already exists.")
     raise "Snapshot #{snap_name} already exists. Another SSA request for this VM is in progress or a previous one failed to clean up properly."
   end
 
@@ -152,15 +154,15 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     vm_obj    = vm_svc.get(vm.name, vm.resource_group)
     os_disk   = vm_obj.properties.storage_profile.os_disk
     snap_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
-    _log.debug ("vm=[#{vm.name}] deleting SSA snapshot #{snap_name}")
+    _log.debug("vm=[#{vm.name}] deleting SSA snapshot #{snap_name}")
     snap_svc.delete(snap_name, vm.resource_group)
   rescue => err
-    _log.error ("vm=[#{vm.name}], error: #{err}")
+    _log.error("vm=[#{vm.name}], error: #{err}")
     _log.debug { err.backtrace.join("\n") }
   end
 
   def snapshot_service(connection = nil)
-    _log.debug ("Enter")
+    _log.debug("Enter")
     connection ||= connect
     ::Azure::Armrest::Storage::SnapshotService.new(connection)
   end

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -34,6 +34,8 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   before_create :ensure_managers
   before_update :ensure_managers_zone_and_provider_region
 
+  SSA_SNAPSHOT_SUFFIX = "__EVM__SSA__SNAPSHOT".freeze
+
   # If the Microsoft.Insights Azure provider is not registered, then neither
   # events nor metrics are supported for that EMS.
   #
@@ -129,7 +131,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
                          :sourceResourceId => os_disk.managed_disk.id
                        }
                      } }
-    snap_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
+    snap_name = "#{os_disk.name}#{SSA_SNAPSHOT_SUFFIX}"
     _log.debug("vm=[#{vm.name}] creating SSA snapshot #{snap_name}")
     begin
       snap_svc.get(snap_name, vm.resource_group)
@@ -153,7 +155,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     snap_svc  = snapshot_service(conf)
     vm_obj    = vm_svc.get(vm.name, vm.resource_group)
     os_disk   = vm_obj.properties.storage_profile.os_disk
-    snap_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
+    snap_name = "#{os_disk.name}#{SSA_SNAPSHOT_SUFFIX}"
     _log.debug("vm=[#{vm.name}] deleting SSA snapshot #{snap_name}")
     snap_svc.delete(snap_name, vm.resource_group)
   rescue => err

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -114,4 +114,57 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
+
+  def vm_create_evm_snapshot(vm, options = {})
+    conf     = connect(options)
+    vm_svc   = vm.provider_service(conf)
+    snap_svc = snapshot_service(conf)
+    vm_obj   = vm_svc.get(vm.name, vm.resource_group)
+    return unless vm_obj.managed_disk?
+    os_disk      = vm_obj.properties.storage_profile.os_disk
+    snap_options = { :location => vm.location,
+                     :properties => {
+                       :creationData => {
+                         :createOption => "Copy",
+                         :sourceResourceId => os_disk.managed_disk.id
+                       }
+                     }
+                   }
+    snap_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
+    _log.debug "vm=[#{vm.name}] creating SSA snapshot #{snap_name}"
+    begin
+      snap_svc.get(snap_name, vm.resource_group)
+    rescue ::Azure::Armrest::NotFoundException, ::Azure::Armrest::ResourceNotFoundException => err
+      begin
+        snap_svc.create(snap_name, vm.resource_group, snap_options)
+        return snap_name
+      rescue => err
+        _log.error "vm=[#{vm.name}], error: #{err}"
+        _log.debug { err.backtrace.join("\n") }
+        raise "Error #{err} creating SSA Snapshot #{snap_name}"
+      end
+    end
+    _log.error "SSA Snapshot #{snap_name} already exists."
+    raise "Snapshot #{snap_name} already exists. Another SSA request for this VM is in progress or a previous one failed to clean up properly."
+  end
+
+  def vm_delete_evm_snapshot(vm, options = {})
+    conf      = connect(options)
+    vm_svc    = vm.provider_service(conf)
+    snap_svc  = snapshot_service(conf)
+    vm_obj    = vm_svc.get(vm.name, vm.resource_group)
+    os_disk   = vm_obj.properties.storage_profile.os_disk
+    snap_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
+    _log.debug "vm=[#{vm.name}] deleting SSA snapshot #{snap_name}"
+    snap_svc.delete(snap_name, vm.resource_group)
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+    _log.debug { err.backtrace.join("\n") }
+  end
+
+  def snapshot_service(connection = nil)
+    _log.debug "Enter"
+    connection ||= connect
+    ::Azure::Armrest::Storage::SnapshotService.new(connection)
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -122,16 +122,13 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     vm_obj   = vm_svc.get(vm.name, vm.resource_group)
     return unless vm_obj.managed_disk?
     os_disk      = vm_obj.properties.storage_profile.os_disk
-    snap_options = { :location => vm.location,
+    snap_options = { :location   => vm.location,
                      :properties => {
                        :creationData => {
-                         :createOption => "Copy",
-                         :sourceResourceId => os_disk.managed_disk.id
-                       }
-                     }
-                   }
+                         :createOption     => "Copy",
+                         :sourceResourceId => os_disk.managed_disk.id } } }
     snap_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
-    _log.debug "vm=[#{vm.name}] creating SSA snapshot #{snap_name}"
+    _log.debug ("vm=[#{vm.name}] creating SSA snapshot #{snap_name}")
     begin
       snap_svc.get(snap_name, vm.resource_group)
     rescue ::Azure::Armrest::NotFoundException, ::Azure::Armrest::ResourceNotFoundException => err
@@ -139,12 +136,12 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
         snap_svc.create(snap_name, vm.resource_group, snap_options)
         return snap_name
       rescue => err
-        _log.error "vm=[#{vm.name}], error: #{err}"
+        _log.error ("vm=[#{vm.name}], error: #{err}")
         _log.debug { err.backtrace.join("\n") }
         raise "Error #{err} creating SSA Snapshot #{snap_name}"
       end
     end
-    _log.error "SSA Snapshot #{snap_name} already exists."
+    _log.error ("SSA Snapshot #{snap_name} already exists.")
     raise "Snapshot #{snap_name} already exists. Another SSA request for this VM is in progress or a previous one failed to clean up properly."
   end
 
@@ -155,15 +152,15 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     vm_obj    = vm_svc.get(vm.name, vm.resource_group)
     os_disk   = vm_obj.properties.storage_profile.os_disk
     snap_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
-    _log.debug "vm=[#{vm.name}] deleting SSA snapshot #{snap_name}"
+    _log.debug ("vm=[#{vm.name}] deleting SSA snapshot #{snap_name}")
     snap_svc.delete(snap_name, vm.resource_group)
   rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
+    _log.error ("vm=[#{vm.name}], error: #{err}")
     _log.debug { err.backtrace.join("\n") }
   end
 
   def snapshot_service(connection = nil)
-    _log.debug "Enter"
+    _log.debug ("Enter")
     connection ||= connect
     ::Azure::Armrest::Storage::SnapshotService.new(connection)
   end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm.rb
@@ -2,11 +2,6 @@ class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudM
   include_concern 'Operations'
   include_concern 'ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared'
 
-  def provider_service(connection = nil)
-    connection ||= ext_management_system.connect
-    ::Azure::Armrest::VirtualMachineService.new(connection)
-  end
-
   #
   # Relationship methods
   #

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
@@ -1,4 +1,14 @@
 module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
   extend ActiveSupport::Concern
   include_concern 'Scanning'
+
+  def provider_service(connection = nil)
+    connection ||= ext_management_system.connect
+    ::Azure::Armrest::VirtualMachineService.new(connection)
+  end
+
+  # The resource group is stored as part of the uid_ems. This splits it out.
+  def resource_group
+    uid_ems.split('\\')[1]
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
@@ -6,9 +6,4 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
     connection ||= ext_management_system.connect
     ::Azure::Armrest::VirtualMachineService.new(connection)
   end
-
-  # The resource group is stored as part of the uid_ems. This splits it out.
-  def resource_group
-    uid_ems.split('\\')[1]
-  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
@@ -14,12 +14,12 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
     require 'MiqVm/miq_azure_vm'
 
     vm_args = { :name => name }
-    _log.debug "name: #{name} (template = #{template})"
+    _log.debug ("name: #{name} (template = #{template})")
     if template
-      _log.debug "image_uri: #{uid_ems}"
+      _log.debug ("image_uri: #{uid_ems}")
       vm_args[:image_uri] = uid_ems
     else
-      _log.debug "resource_group: #{resource_group}"
+      _log.debug ("resource_group: #{resource_group}")
       vm_args[:resource_group] = resource_group
     end
 
@@ -61,13 +61,13 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
     begin
       vm_obj = provider_service.get(name, resource_group)
       if vm_obj.managed_disk?
-        _log.debug "VM #{name} has a Managed Disk - Snapshot required for Scan"
+        _log.debug ("VM #{name} has a Managed Disk - Snapshot required for Scan")
         return true
       end
     rescue => err
-      _log.error "Error Class=#{err.class.name}, Message=#{err.message}"
+      _log.error ("Error Class=#{err.class.name}, Message=#{err.message}")
     end
-    _log.debug "VM #{name} does not have a Managed Disk - no Snapshot required for Scan"
+    _log.debug ("VM #{name} does not have a Managed Disk - no Snapshot required for Scan")
     false
   end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
@@ -56,4 +56,18 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
   def requires_storage_for_scan?
     false
   end
+
+  def require_snapshot_for_scan?
+    begin
+      vm_obj = provider_service.get(name, resource_group)
+      if vm_obj.managed_disk?
+        _log.debug "VM #{name} has a Managed Disk - Snapshot required for Scan"
+        return true
+      end
+    rescue => err
+      _log.error "Error Class=#{err.class.name}, Message=#{err.message}"
+    end
+    _log.debug "VM #{name} does not have a Managed Disk - no Snapshot required for Scan"
+    false
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
@@ -14,12 +14,12 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
     require 'MiqVm/miq_azure_vm'
 
     vm_args = { :name => name }
-    _log.debug ("name: #{name} (template = #{template})")
+    _log.debug("name: #{name} (template = #{template})")
     if template
-      _log.debug ("image_uri: #{uid_ems}")
+      _log.debug("image_uri: #{uid_ems}")
       vm_args[:image_uri] = uid_ems
     else
-      _log.debug ("resource_group: #{resource_group}")
+      _log.debug("resource_group: #{resource_group}")
       vm_args[:resource_group] = resource_group
     end
 
@@ -61,13 +61,13 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
     begin
       vm_obj = provider_service.get(name, resource_group)
       if vm_obj.managed_disk?
-        _log.debug ("VM #{name} has a Managed Disk - Snapshot required for Scan")
+        _log.debug("VM #{name} has a Managed Disk - Snapshot required for Scan")
         return true
       end
     rescue => err
-      _log.error ("Error Class=#{err.class.name}, Message=#{err.message}")
+      _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
     end
-    _log.debug ("VM #{name} does not have a Managed Disk - no Snapshot required for Scan")
+    _log.debug("VM #{name} does not have a Managed Disk - no Snapshot required for Scan")
     false
   end
 end


### PR DESCRIPTION
Add code to snapshot VMs with Managed Disks,
as well as the code to delete the snapshots upon
completion of SSA (or aborts).
Also check that the disk requires a snapshot, which for now
is just for Managed Disks.  This will change in a subsequent PR.

This is one of several PRs required to add support for SSA for Managed Disks,
that is is response to the following BZs:
https://bugzilla.redhat.com/show_bug.cgi?id=1475540
and
https://bugzilla.redhat.com/show_bug.cgi?id=1459612

A PR for the azure-armrest gem has already been merged in advance of this:
https://github.com/ManageIQ/azure-armrest#299

A PR for the ManageIQ repo has been added as well to work with this -
https://github.com/ManageIQ/manageiq#15865

Also a PR for the manageiq-smartstate gem is required for this - 
https://github.com/ManageIQ/manageiq-smartstate/pull/23


**# Links**

https://bugzilla.redhat.com/show_bug.cgi?id=1475540
https://bugzilla.redhat.com/show_bug.cgi?id=1459612
ManageIQ/azure-armrest#299
ManageIQ/manageiq#15865
ManageIQ/manageiq-smartstate#23

**# Steps for Testing/QA**

Add an Azure VM with a Managed Disk.
Run SmartState Analysis against the VM.

@roliveri @hsong-rh please review for SSA sanity.
@bronaghs @blomquisg please review or assign an appropriate providers person to do so.
Thanks!