### PR TITLE
Bump azure-armrest dependency to 0.8.2

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.8.1"
+  s.add_dependency "azure-armrest", "~>0.8.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The 0.8.2 release contains some important bug fixes and features. We should upgrade.

https://github.com/ManageIQ/azure-armrest/blob/master/CHANGES#L1-L16