### PR TITLE
Refresher sets proper OrchestrationTemplate type

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_template.rb
@@ -1,4 +1,8 @@
 class ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate < ::OrchestrationTemplate
+  def format
+    'json'.freeze
+  end
+
   def parameter_groups
     # Azure format does not have the concept of parameter group
     # Place all parameters in one group

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -459,7 +459,7 @@ module ManageIQ::Providers
 
       def parse_stack_template(template)
         new_result = {
-          :type        => "OrchestrationTemplateAzure",
+          :type        => ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate.name,
           :name        => template[:name],
           :description => template[:description],
           :content     => template[:content],

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -625,7 +625,9 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
   end
 
   def assert_specific_orchestration_template
-    @orch_template = OrchestrationTemplateAzure.find_by(:name => "spec-nested-deployment-dont-delete")
+    @orch_template = ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate.find_by(
+      :name => "spec-nested-deployment-dont-delete"
+    )
     expect(@orch_template).to have_attributes(
       :md5 => "05e28d9332a3b60def5fbd66ac031a7d"
     )
@@ -636,7 +638,8 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
 
   def assert_specific_orchestration_stack
     @orch_stack = ManageIQ::Providers::Azure::CloudManager::OrchestrationStack.find_by(
-      :name => "spec-nested-deployment-dont-delete")
+      :name => "spec-nested-deployment-dont-delete"
+    )
     expect(@orch_stack).to have_attributes(
       :status         => "Succeeded",
       :description    => "spec-nested-deployment-dont-delete",


### PR DESCRIPTION
This the continuation of #111. The refresher needs to set the type to the new Azure template class.