### PR TITLE
Don't collect information externally if marketplace images are specified

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -6,7 +6,7 @@ module ManageIQ::Providers
 
       TYPE_DEPLOYMENT = "microsoft.resources/deployments"
 
-      def self.ems_inv_to_hashes(ems, options = nil)
+      def self.ems_inv_to_hashes(ems, options = Config::Options.new)
         new(ems, options).ems_inv_to_hashes
       end
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -37,6 +37,32 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
     @ems.reload
   end
 
+  context "marketplace images" do
+    let(:urns) do
+      [
+        "Foo:Bar:Stuff:1.0",
+        "Foo:Baz:Stuff:1.1",
+        "Foo:Baz:MoreStuff:2.1",
+        "Foo:Baz:MoreStuff:latest"
+      ]
+    end
+
+    let(:settings) do
+      {:ems_refresh => {:azure => {:get_market_images => true, :market_image_urns => urns}}}
+    end
+
+    it "does not collect marketplace images by default" do
+      setup_ems_and_cassette
+      expect(VmOrTemplate.where(:publicly_available => true).count).to eql(0)
+    end
+
+    it "collects only the marketplace images from the settings file if present" do
+      stub_settings_merge(settings)
+      setup_ems_and_cassette
+      expect(VmOrTemplate.where(:publicly_available => true).count).to eql(4)
+    end
+  end
+
   context "template deployments" do
     let(:template_deployment_service) { double }
 


### PR DESCRIPTION
If users choose to collect marketplace images, and there are already urns specified in the configuration file, then there is no need to use azure-armrest to collect information. We already have all the information we need, since the "id" is just the urn, and everything else can be parsed out of the urn directly.

I've also added some comments explaining that selecting marketplace images without specifying any urns will be expensive and slow.

https://bugzilla.redhat.com/show_bug.cgi?id=1491330

Note that this doesn't address the fundamental issue of `VirtualImageMachineService#list_all` being very slow. I will create a separate issue on the azure-armrest repo.