### PR TITLE
Wait for SSA Snapshot Success

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -144,7 +144,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     rescue ::Azure::Armrest::NotFoundException, ::Azure::Armrest::ResourceNotFoundException => err
       begin
         response = snap_svc.create(ssa_snap_name, resource_group, snap_options)
-        raise "Maximum snapshot wait time exceeded" unless snap_svc.wait(response.response_headers, SSA_SNAPSHOT_WAIT_TIME) == "Succeeded"
+        raise "Maximum snapshot wait time exceeded" unless snap_svc.wait(response.response_headers, SSA_SNAPSHOT_WAIT_TIME) =~ /^succe/i
         return ssa_snap_name
       rescue => err
         _log.error("vm=[#{vm.name}], error: #{err}")
@@ -160,7 +160,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     _log.debug("vm=[#{vm.name}] creating SSA snapshot for #{vm.blob_uri}")
     begin
       snapshot_info = vm.storage_acct.create_blob_snapshot(vm.container, vm.blob, vm.key)
-      raise "Maximum snapshot wait time exceeded" unless vm.storage_acct_service.wait(snapshot_info, SSA_SNAPSHOT_WAIT_TIME) == "Succeeded"
+      raise "Maximum snapshot wait time exceeded" unless vm.storage_acct_service.wait(snapshot_info, SSA_SNAPSHOT_WAIT_TIME) =~ /^succe/i
       return snapshot_info[:x_ms_snapshot]
     rescue => err
       _log.error("vm=[#{vm.name}], error:#{err}")

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -18,6 +18,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
 
   include ManageIQ::Providers::Azure::ManagerMixin
 
+  SSA_SNAPSHOT_WAIT_TIME = 1800
   alias_attribute :azure_tenant_id, :uid_ems
 
   has_many :resource_groups, :foreign_key => :ems_id, :dependent => :destroy
@@ -142,7 +143,8 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
       snap_svc.get(ssa_snap_name, resource_group)
     rescue ::Azure::Armrest::NotFoundException, ::Azure::Armrest::ResourceNotFoundException => err
       begin
-        snap_svc.create(ssa_snap_name, resource_group, snap_options)
+        response = snap_svc.create(ssa_snap_name, resource_group, snap_options)
+        raise "Maximum snapshot wait time exceeded" unless snap_svc.wait(response.response_headers, SSA_SNAPSHOT_WAIT_TIME) == "Succeeded"
         return ssa_snap_name
       rescue => err
         _log.error("vm=[#{vm.name}], error: #{err}")
@@ -158,6 +160,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     _log.debug("vm=[#{vm.name}] creating SSA snapshot for #{vm.blob_uri}")
     begin
       snapshot_info = vm.storage_acct.create_blob_snapshot(vm.container, vm.blob, vm.key)
+      raise "Maximum snapshot wait time exceeded" unless vm.storage_acct_service.wait(snapshot_info, SSA_SNAPSHOT_WAIT_TIME) == "Succeeded"
       return snapshot_info[:x_ms_snapshot]
     rescue => err
       _log.error("vm=[#{vm.name}], error:#{err}")

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -18,7 +18,6 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
 
   include ManageIQ::Providers::Azure::ManagerMixin
 
-  SSA_SNAPSHOT_WAIT_TIME = 1800
   alias_attribute :azure_tenant_id, :uid_ems
 
   has_many :resource_groups, :foreign_key => :ems_id, :dependent => :destroy
@@ -144,7 +143,8 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     rescue ::Azure::Armrest::NotFoundException, ::Azure::Armrest::ResourceNotFoundException => err
       begin
         response = snap_svc.create(ssa_snap_name, resource_group, snap_options)
-        raise "Maximum snapshot wait time exceeded" unless snap_svc.wait(response.response_headers, SSA_SNAPSHOT_WAIT_TIME) =~ /^succe/i
+        # wait a minute at a time, allowing the Job Timeout to handle long-running snapshots here
+        next until snap_svc.wait(response.response_headers) =~ /^succe/i
         return ssa_snap_name
       rescue => err
         _log.error("vm=[#{vm.name}], error: #{err}")
@@ -160,7 +160,8 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     _log.debug("vm=[#{vm.name}] creating SSA snapshot for #{vm.blob_uri}")
     begin
       snapshot_info = vm.storage_acct.create_blob_snapshot(vm.container, vm.blob, vm.key)
-      raise "Maximum snapshot wait time exceeded" unless vm.storage_acct_service.wait(snapshot_info, SSA_SNAPSHOT_WAIT_TIME) =~ /^succe/i
+      # wait a minute at a time, allowing the Job Timeout to handle long-running snapshots here
+      next until vm.storage_acct_service.wait(snapshot_info) =~ /^succe/i
       return snapshot_info[:x_ms_snapshot]
     rescue => err
       _log.error("vm=[#{vm.name}], error:#{err}")


### PR DESCRIPTION
We need to wait for success status from the SSA Snapshot
operations for both Managed and non-managed (blob) disks.
The Managed snapshot will use the Snapshot Service to wait
while the blob snapshot will use the Storage Account Service
to wait.

This is the story of the continuing saga of the BZs:
https://bugzilla.redhat.com/show_bug.cgi?id=1463780 (for a running non-managed disk VM)
and
https://bugzilla.redhat.com/show_bug.cgi?id=1475540 (for Managed Disk VMs)

This PR needs to be back ported to FINE and will be added to a hot fix covering both of these BZs.
Not needing to be back ported but still needed to be added are a PR to bump the manageiq-smartstate gem version to 1.4 and one in manageiq to use 1.4.

@roliveri please review for sanity (especially the length of the wait)
@bronaghs or @djberg96 please review and merge so we can put these blocker BZs to bed and push out the hot fix.  Thanks all.