### PR TITLE
[FINE] Treat Resource Group as a String not an Object

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -137,7 +137,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     _log.debug("vm=[#{vm.name}] creating SSA snapshot #{vm.ssa_snap_name}")
     begin
       ssa_snap_name  = vm.ssa_snap_name
-      resource_group = vm.resource_group.name
+      resource_group = vm.resource_group
       snap_svc.get(ssa_snap_name, resource_group) # Check if snapshot already exists
     rescue ::Azure::Armrest::NotFoundException, ::Azure::Armrest::ResourceNotFoundException => err
       begin
@@ -188,7 +188,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   def vm_delete_managed_snapshot(vm, _options = {})
     snap_svc = snapshot_service(@connection)
     _log.debug("vm=[#{vm.name}] deleting SSA snapshot #{vm.ssa_snap_name}")
-    snap_svc.delete(vm.ssa_snap_name, vm.resource_group.name)
+    snap_svc.delete(vm.ssa_snap_name, vm.resource_group)
   rescue => err
     _log.error("vm=[#{vm.name}], error: #{err} deleting SSA snapshot #{vm.ssa_snap_name}")
     _log.debug { err.backtrace.join("\n") }

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
@@ -34,7 +34,7 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
   end
 
   def vm_object
-    @vm_object ||= provider_service.get(name, resource_group.name)
+    @vm_object ||= provider_service.get(name, resource_group)
   end
 
   def os_disk


### PR DESCRIPTION
A previous change assumed that  PR https://github.com/ManageIQ/manageiq-providers-azure/pull/115 had been backported from Fine to upstream converting
Resource Groups to objects which had to be dereferenced to get to the name attribute.
This PR had not been backported so we need to treat the value as a String.

This is for high priority BZ https://bugzilla.redhat.com/show_bug.cgi?id=1475540
and goes hand in hand with https://github.com/ManageIQ/manageiq-gems-pending/pull/273

This is for FINE only.

@roliveri please review.  @djberg96 and/or @bronaghs please validate based on the above info and our discussions.