### PR TITLE
Use azure-armrest gem version 0.8.3

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.8.2"
+  s.add_dependency "azure-armrest", "~>0.8.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Subject says it all.  This will allow refactoring changes
in the new version of the gem to be used in support of the fixes
for https://bugzilla.redhat.com/show_bug.cgi?id=1488967 which is
a high priority issue running SSA on Azure Managed Disks.

@djberg96 please review and merge when appropriate.  Thanks!
@roliveri FYI.