### PR TITLE
Don't assume NIC IP configuration has subnet

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
@@ -391,7 +391,7 @@ class ManageIQ::Providers::Azure::NetworkManager::RefreshParser
   def parse_cloud_subnet_network_port(network_port)
     {
       :address      => network_port.properties.try(:private_ip_address),
-      :cloud_subnet => @data_index.fetch_path(:cloud_subnets, network_port.properties.subnet.id)
+      :cloud_subnet => @data_index.fetch_path(:cloud_subnets, network_port.properties.try(:subnet).try(:id))
     }
   end
 


### PR DESCRIPTION
Not all IP configurations for all NIC's will have a subnet. If it doesn't, the refresh parser for the NetworkManager will break. This fixes that.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1494143