### PR TITLE
SSA Support for Managed Images

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
@@ -47,12 +47,11 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
   end
 
   def os_disk
-    if template 
-      @os_disk ||= image_object.properties.storage_profile.os_disk
-    else
-      @os_disk ||= vm_object.properties.storage_profile.os_disk
-    end
-    @os_disk
+    @os_disk ||= if template
+                   image_object.properties.storage_profile.os_disk
+                 else
+                   vm_object.properties.storage_profile.os_disk
+                 end
   end
 
   delegate :managed_disk?, to: :vm_object
@@ -63,7 +62,7 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
   end
 
   def managed_resource_group
-    return nil unless (ems_ref =~ /^\/subscriptions\//i)
+    return nil unless ems_ref =~ /^\/subscriptions\//i
     ref_parts = ems_ref.split('/')
     if ref_parts[3] =~ /resourceGroups/i
       return ref_parts[4]
@@ -84,8 +83,8 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
     if template
       if ems_ref =~ /^https:/
         @blob_uri ||= ems_ref
-      else
-        @blob_uri ||= os_disk.blob_uri if os_disk.try(:blob_uri)
+      elsif os_disk.try(:blob_uri)
+        @blob_uri ||= os_disk.blob_uri
       end
     else
       @blob_uri ||= os_disk.vhd.uri

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
@@ -16,8 +16,14 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
     vm_args = { :name => name }
     _log.debug("name: #{name} (template = #{template})")
     if template
-      _log.debug("image_uri: #{uid_ems}")
-      vm_args[:image_uri] = uid_ems
+      if managed_image?
+        vm_args[:resource_group] = managed_resource_group
+        vm_args[:managed_image]  = managed_image_disk_name
+      elsif blob_uri
+        vm_args[:image_uri] = blob_uri
+      else
+        vm_args[:image_uri] = uid_ems
+      end
     else
       vm_args[:resource_group] = resource_group
       vm_args[:snapshot] = ost.scanData["snapshot"]["name"] unless managed_disk?


### PR DESCRIPTION
Add support for SSA on Managed Images.  These
images may or may not have Managed Disks as well.

These changes are in support of blocker BZ https://bugzilla.redhat.com/show_bug.cgi?id=1496523.
Parallel changes have been added to the manageiq-smartstate gem by way of
PR https://github.com/ManageIQ/manageiq-smartstate/pull/31.

@roliveri please review for rationality with Smartstate.  @bronaghs and/or @djberg96 please review
as well and merge when appropriate.  Adding the Fine back port label as well.