### PR TITLE
Update azure-armrest to 0.8.4

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.8.3"
+  s.add_dependency "azure-armrest", "~>0.8.4"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This PR updates the gemspec by updating the azure-armest gem from 0.8.3 to 0.8.4. The 0.8.4 release notably reduces memory in the `StorageAccountService#list_all_private_images` method. There's also a logging fix.