### PR TITLE
fix factory orchestration_stack for azure

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -2,7 +2,7 @@ require 'azure-armrest'
 
 describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
   let(:ems) { FactoryGirl.create(:ems_azure_with_authentication) }
-  let(:template) { FactoryGirl.create(:orchestration_template_azure_with_content) }
+  let(:template) { FactoryGirl.create(:orchestration_template_azure_in_json) }
   let(:orchestration_service) { double("orchestration service") }
   let(:the_raw_stack) do
     Azure::Armrest::TemplateDeployment.new(


### PR DESCRIPTION
Point the template to use the new factory.
The old one has been removed from manageiq repo.