### PR TITLE
Update azure-armrest to 0.9.0

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.8.4"
+  s.add_dependency "azure-armrest", "~>0.9.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This brings up the azure-armrest gem to 0.9.0. It is compatible with the 0.8.x release, but does include some fundamental underlying changes that necessitated a major version bump for people who use this gem outside of ManageIQ.

The major change is a major memory reduction for the `list_all_private_images` method.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1431912