### PR TITLE
Pass resource group as a string to the instance delete method

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
@@ -6,7 +6,7 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations
     unless ext_management_system
       raise _("VM has no %{table}, unable to destroy VM") % {:table => ui_lookup(:table => "ext_management_systems")}
     end
-    provider_service.delete_associated_resources(name, resource_group)
+    provider_service.delete_associated_resources(name, resource_group.name)
     update_attributes!(:raw_power_state => "Deleting")
   end
 end


### PR DESCRIPTION
The instance delete operation passes a resource group object to the armrest gem delete function but should pass a string representation.
This was introduced [here](https://github.com/ManageIQ/manageiq/pull/14000) 

https://bugzilla.redhat.com/show_bug.cgi?id=1507574