### PR TITLE
Update azure-armrest gem to 0.9.3

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.9.1"
+  s.add_dependency "azure-armrest", "~>0.9.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This PR updates the azure-armrest dependency to 0.9.3. It contains important bug fixes from 0.9.1, including a fix for the `StorageAccountService#list_private_images` method which affects provisioning, as well as a bug in a `sleep` call that potentially affects metrics collection.

https://bugzilla.redhat.com/show_bug.cgi?id=1504314

It also includes a fix for the TemplateDeploymentService#delete_associated_resources method.

https://bugzilla.redhat.com/show_bug.cgi?id=1497175


