### PR TITLE
Pass manageiq-smartstate the Resource Group Name not the Object

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
@@ -25,7 +25,7 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
         vm_args[:image_uri] = uid_ems
       end
     else
-      vm_args[:resource_group] = resource_group
+      vm_args[:resource_group] = resource_group.name
       vm_args[:snapshot] = ost.scanData["snapshot"]["name"]
     end
 


### PR DESCRIPTION
A previous fix that was backported to the FINE branch fixed this
issue caused by the resource group being changed from a string
to an object a while ago but the fix never went into the
MASTER branch.  This will fix in Master and should be back-ported
to Gaprindashvili.  It should *not* go into the FINE branch.

https://bugzilla.redhat.com/show_bug.cgi?id=1507977 is the bug for this PR.

@roliveri @hsong-rh @bronaghs @djberg96 please review and merge.  