### PR TITLE
Downcase ems_ref for resource groups

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -217,7 +217,7 @@ module ManageIQ::Providers
       end
 
       def parse_resource_group(resource_group)
-        uid = resource_group.id
+        uid = resource_group.id.downcase
         new_result = {
           :type    => 'ManageIQ::Providers::Azure::ResourceGroup',
           :name    => resource_group.name,

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -61,13 +61,13 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
   # the resource group they live in, we do not filter by region here.
   #
   def resource_groups
-    @resource_groups ||= @rgs.list
+    @resource_groups ||= @rgs.list(:all => true)
   end
 
   # Given an object, return the matching ems_ref for its resource group.
   #
   def get_resource_group_ems_ref(object)
-    "/subscriptions/#{object.subscription_id}/resourceGroups/#{object.resource_group.downcase}"
+    "/subscriptions/#{object.subscription_id}/resourcegroups/#{object.resource_group}".downcase
   end
 
   # TODO(lsmola) NetworkManager, move below methods under NetworkManager, once it is not needed in Cloudmanager

--- a/spec/models/manageiq/providers/azure/refresh_helper_methods_spec.rb
+++ b/spec/models/manageiq/providers/azure/refresh_helper_methods_spec.rb
@@ -17,7 +17,7 @@ describe ManageIQ::Providers::Azure::RefreshHelperMethods do
       virtual_machine_eastus.subscription_id = "abc123"
       virtual_machine_eastus.resource_group = "Test_Group"
 
-      expected = "/subscriptions/abc123/resourceGroups/test_group"
+      expected = "/subscriptions/abc123/resourcegroups/test_group"
       expect(@ems_azure.get_resource_group_ems_ref(virtual_machine_eastus)).to eql(expected)
     end
   end


### PR DESCRIPTION
There's currently a bug where the resource group will not be associated with the VM if there's a case mismatch. In addition, it's possible not all resource groups will be collected if there is a very large number of resource groups (I think 1000+, but the docs aren't specific).

Consequently, the ems_ref for a resource_group object is completely downcased, and the `get_resource_group_ems_ref` method was updated accordingly.

UPDATE: To add a little more information as to why this is necessary, it goes back to the Azure REST API behavior. The first issue is that the JSON output from requests does not include resource group information. We added our own `BaseModel#resource_group` method. That means parsing the resource group out of the ID string. The az command line does the same thing.

The second issue is that we cannot guarantee that the case of the resource group matches the actual value. Why? Part of the answer is that their REST API returns the resource group name in the same case as the request itself. In other words, if you do `az vm show -n bar -g foo` (or the equivalent code using the azure-armrest gem) you will get 'foo' returned as the resource group. But if you do `az vm show -n bar -g FOO` you will get 'FOO' returned as the resource group.

The remaining answer is that `instance.resource_group` within our refresh parser returns an uppercase value. I don't remember WHY it does that (we can dig into that later if you want), I just know that's what I see when I log it. That's why the original code had the `downcase` method on the resource_group name - because otherwise it would never find the ems_ref. With the `downcase` method it *usually* worked because most resource group names are lowercase. I had forgotten they could be mixed case.

But, that's academic anyway. Even if we were getting the expected case from `instance.resource_group`, it's simply not guaranteed to be what we expect by the Azure REST API. I've run into this already with location data where a couple regions inexplicably mixed case while all the rest were lowercase. Consequently, the best thing to do is to simply downcase the ems_ref completely.

https://bugzilla.redhat.com/show_bug.cgi?id=1503295