### PR TITLE
Smart state Snapshot Managed Disk Name 80 Char Limit

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
@@ -1,7 +1,8 @@
 module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
   extend ActiveSupport::Concern
   include_concern 'Scanning'
-  SSA_SNAPSHOT_SUFFIX = "__EVM__SSA__SNAPSHOT".freeze
+  SSA_SNAPSHOT_SUFFIX = "_SSA_SNAPSHOT".freeze
+  SSA_NAME_MAX        = 80
 
   def provider_service(connection = nil)
     @connection ||= connection || ext_management_system.connect
@@ -76,7 +77,12 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
   end
 
   def ssa_snap_name
-    @ssa_snap_name ||= "#{os_disk.name}#{SSA_SNAPSHOT_SUFFIX}"
+    @ssa_snap_name ||= if "#{name}#{SSA_SNAPSHOT_SUFFIX}".size > SSA_NAME_MAX
+                         name_end = SSA_NAME_MAX - SSA_SNAPSHOT_SUFFIX.size - 1
+                         "#{name[0..name_end]}#{SSA_SNAPSHOT_SUFFIX}"
+                       else
+                         "#{name}#{SSA_SNAPSHOT_SUFFIX}"
+                       end
   end
 
   def blob_uri

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
@@ -26,7 +26,7 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
       end
     else
       vm_args[:resource_group] = resource_group
-      vm_args[:snapshot] = ost.scanData["snapshot"]["name"] unless managed_disk?
+      vm_args[:snapshot] = ost.scanData["snapshot"]["name"]
     end
 
     ost.scanTime = Time.now.utc unless ost.scanTime


### PR DESCRIPTION
Changes required since there is an 80 character limit on the name
of the snapshot for a managed disk -
1) Use the VM name instead of the OS DIsk name.
2) Shorten the suffix for the snapshot from 20 to 13 characters.
3) If the above is still longer than 80 characters truncate the VM name to 80-13 characters.
4) Always pass the snapshot name to MiqAzureVm so that it does not have to compute the name
   as well.

This PR goes hand-in-hand with https://github.com/ManageIQ/manageiq-smartstate/pull/44 which receives the name of the snapshot to use when communicating with Azure.  Both PRs fix the issue https://bugzilla.redhat.com/show_bug.cgi?id=1508577.
The two PRs can be merged in any order.  The GEMfile  for this provider must be updated after the smartstate gem is updated.

This PR should be back ported to both FINE and Gaprindashvili.

@roliveri @hsong-rh @bronaghs @djberg96 please review and merge.  Thanks.