### PR TITLE
Fix exception handing for credential validation on raw_connect

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -10,9 +10,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
   end
 
   def verify_credentials(_auth_type = nil, options = {})
-    connection_rescue_block do
-      connect(options)
-    end
+    connect(options)
   end
 
   module ClassMethods

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -93,14 +93,16 @@ describe ManageIQ::Providers::Azure::CloudManager do
     end
 
     context "#validation" do
+      before do
+        @e.subscription = "not_blank"
+      end
       it "handles unknown error" do
-        allow(ManageIQ::Providers::Azure::CloudManager).to receive(:raw_connect).and_raise(StandardError)
+        allow(Azure::Armrest::Configuration).to receive(:new).and_raise(StandardError)
         expect { @e.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError, /Unexpected response returned*/)
       end
 
       it "handles incorrect password" do
-        allow(ManageIQ::Providers::Azure::CloudManager).to receive(:raw_connect).and_raise(
-          Azure::Armrest::UnauthorizedException.new(nil, nil, nil))
+        allow(Azure::Armrest::Configuration).to receive(:new).and_raise(Azure::Armrest::UnauthorizedException.new(nil, nil, nil))
         expect { @e.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError, /Incorrect credentials*/)
       end
     end


### PR DESCRIPTION
When provider is added the credentials validation is newly done via `raw_connect` (class method) instead of `verify_credentials` (needed EMS object). Further reading on this change can be found here: ManageIQ/manageiq-ui-classic#1580

This change ensures that exceptions are handled properly, because the `verify_credentials` is not called anymore.