### PR TITLE
Add an Azure STI class for ResourceGroup

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -219,7 +219,7 @@ module ManageIQ::Providers
       def parse_resource_group(resource_group)
         uid = resource_group.id
         new_result = {
-          :type    => "ResourceGroup",
+          :type    => 'ManageIQ::Providers::Azure::ResourceGroup',
           :name    => resource_group.name,
           :ems_ref => uid,
         }

--- a/app/models/manageiq/providers/azure/resource_group.rb
+++ b/app/models/manageiq/providers/azure/resource_group.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Azure::ResourceGroup < ResourceGroup
+end

--- a/spec/factories/resource_group.rb
+++ b/spec/factories/resource_group.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :azure_resource_group,
+          :parent => :resource_group,
+          :class  => 'ManageIQ::Providers::Azure::ResourceGroup'
+end

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -143,8 +143,8 @@ describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
                                           :supports_64_bit => true)
         ems.flavors << FactoryGirl.create(:flavor, :name => "Standard_A1", :supports_32_bit => false,
                                           :supports_64_bit => true)
-        ems.resource_groups << FactoryGirl.create(:resource_group)
-        ems.resource_groups << FactoryGirl.create(:resource_group)
+        ems.resource_groups << FactoryGirl.create(:resource_group, :type => 'ManageIQ::Providers::Azure::ResourceGroup')
+        ems.resource_groups << FactoryGirl.create(:resource_group, :type => 'ManageIQ::Providers::Azure::ResourceGroup')
       end
 
       it "#allowed_instance_types" do

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -143,8 +143,8 @@ describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
                                           :supports_64_bit => true)
         ems.flavors << FactoryGirl.create(:flavor, :name => "Standard_A1", :supports_32_bit => false,
                                           :supports_64_bit => true)
-        ems.resource_groups << FactoryGirl.create(:resource_group, :type => 'ManageIQ::Providers::Azure::ResourceGroup')
-        ems.resource_groups << FactoryGirl.create(:resource_group, :type => 'ManageIQ::Providers::Azure::ResourceGroup')
+        ems.resource_groups << FactoryGirl.create(:azure_resource_group)
+        ems.resource_groups << FactoryGirl.create(:azure_resource_group)
       end
 
       it "#allowed_instance_types" do

--- a/spec/models/manageiq/providers/azure/resource_group_spec.rb
+++ b/spec/models/manageiq/providers/azure/resource_group_spec.rb
@@ -1,0 +1,7 @@
+describe ManageIQ::Providers::Azure::ResourceGroup do
+  context 'inheritance' do
+    it 'is a subclass of ResourceGroup' do
+      expect(subject).to be_a_kind_of(ResourceGroup)
+    end
+  end
+end


### PR DESCRIPTION
This adds a ManageIQ::Provider::Azure::ResourceGroup class that subclasses ManageIQ::ResourceGroup. It then updates the refresh parser to use it when setting the resource group.

Prerequisite for ManageIQ/manageiq-schema#123

Ultimately goes towards solving https://bugzilla.redhat.com/show_bug.cgi?id=1503295