### PR TITLE
Upgrade manageiq-smartstate gem to 0.2.3

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency "azure-armrest", "~>0.9.3"
+  s.add_dependency "manageiq-smartstate", "~>0.2.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Upgrade to 0.2.3 to pull the fix for https://github.com/ManageIQ/manageiq-smartstate/pull/44
required for BZ fix for https://bugzilla.redhat.com/show_bug.cgi?id=1508577

@roliveri please review and merge.  Thanks.