### PR TITLE
Don't include manageiq-smartstate gem in gemspec here

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency "azure-armrest", "~>0.9.3"
-  s.add_dependency "manageiq-smartstate", "~>0.2.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The manageiq-smartstate gem version 0.2.3 was previously included in this gemspec
but since the gem is also included in the main ManageIQ repo Gemfile at the greatest
0.2 version the line in this provider repo is extraneous and incorrectly ties us to
a lower version than necessary.  Version 0.2.4 was just released and removing the
gem version from this gemspec file allows us to use the newest version.

This is in support of PR https://github.com/ManageIQ/manageiq-smartstate/pull/45
which contains a fix for BZ https://bugzilla.redhat.com/show_bug.cgi?id=1490488.

@roliveri @hsong-rh and maybe @djberg96 please review and merge when appropriate.  Thanks.