### PR TITLE
Select only the event fields that we need

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
@@ -29,7 +29,8 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream
   def get_events
     # Grab only events for the last minute if this is the first poll
     filter = @since ? "eventTimestamp ge #{@since}" : "eventTimestamp ge #{startup_interval}"
-    events = connection.list(:filter => filter, :all => true).sort_by(&:event_timestamp)
+    fields = 'authorization,description,eventName,eventTimestamp,resourceGroupName,resourceId,resourceType'
+    events = connection.list(:filter => filter, :select => fields, :all => true).sort_by(&:event_timestamp)
 
     # HACK: the Azure Insights API does not support the 'gt' (greater than relational operator)
     # therefore we have to poll from 1 millisecond past the timestamp of the last event to avoid

--- a/spec/fixtures/events/storage_account.json
+++ b/spec/fixtures/events/storage_account.json
@@ -1,0 +1,19 @@
+{
+  "authorization":{
+    "action":"Microsoft.Storage/storageAccounts/listKeys/action",
+    "scope":"/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Storage/storageAccounts/foodiagnostics"
+  },
+  "description":"",
+  "eventName":{
+    "value":"BeginRequest",
+    "localizedValue":"Begin request"
+  },
+  "id":"/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Storage/storageAccounts/foodiagnostics/events/b26d3cfc-c50e-493b-ab57-1bd6860d8fb5/ticks/636467630868082029",
+  "resourceGroupName":"foo1",
+  "resourceId":"/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Storage/storageAccounts/foodiagnostics",
+  "resourceType":{
+    "value":"Microsoft.Storage/storageAccounts",
+    "localizedValue":"Microsoft.Storage/storageAccounts"
+  },
+  "eventTimestamp":"2017-11-20T08:24:46.8082029Z"
+}

--- a/spec/fixtures/events/vm_no_description.json
+++ b/spec/fixtures/events/vm_no_description.json
@@ -1,0 +1,14 @@
+{
+  "eventName":{
+    "value":"New Recommendation",
+    "localizedValue":"New Recommendation"
+  },
+  "id":"/subscriptions/xyz/resourceGroups/foo/providers/Microsoft.Compute/virtualMachines/my_vm1/events/c06c7125-c863-42f6-a991-98175d5ee5c5/ticks/636468902825032036",
+  "resourceGroupName":"foo",
+  "resourceId":"/subscriptions/xyz/resourceGroups/foo/providers/Microsoft.Compute/virtualMachines/my_vm1",
+  "resourceType":{
+    "value":"Microsoft.Compute/virtualMachines",
+    "localizedValue":"Microsoft.Compute/virtualMachines"
+  },
+  "eventTimestamp":"2017-11-21T19:44:42.5032036Z"
+}

--- a/spec/fixtures/events/vm_with_description.json
+++ b/spec/fixtures/events/vm_with_description.json
@@ -1,0 +1,19 @@
+{
+  "authorization":{
+    "action":"Microsoft.Compute/virtualMachines/deallocate/action",
+    "scope":"/subscriptions/xyz/resourceGroups/bar/providers/Microsoft.Compute/virtualMachines/another_vm"
+  },
+  "description":"",
+  "eventName":{
+    "value":"BeginRequest",
+    "localizedValue":"BeginRequest"
+  },
+  "id":"/subscriptions/xyz/resourceGroups/bar/providers/Microsoft.Compute/virtualMachines/another_vm/events/176f7676-a318-4c48-b1c6-e0e64a555aa1/ticks/636468904275023866",
+  "resourceGroupName":"bar",
+  "resourceId":"/subscriptions/xyz/resourceGroups/bar/providers/Microsoft.Compute/virtualMachines/another_vm",
+  "resourceType":{
+    "value":"Microsoft.Compute/virtualMachines",
+    "localizedValue":"Microsoft.Compute/virtualMachines"
+  },
+  "eventTimestamp":"2017-11-21T19:47:07.5023866Z"
+}

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_parser_spec.rb
@@ -1,0 +1,61 @@
+describe ManageIQ::Providers::Azure::CloudManager::EventParser do
+  let(:vm_with_description) do
+    ManageIQ::Providers::Azure::Engine.root.join('spec/fixtures/events/vm_with_description.json')
+  end
+
+  let(:vm_no_description) do
+    ManageIQ::Providers::Azure::Engine.root.join('spec/fixtures/events/vm_no_description.json')
+  end
+
+  let(:storage_account) do
+    ManageIQ::Providers::Azure::Engine.root.join('spec/fixtures/events/storage_account.json')
+  end
+
+  context 'event_to_hash' do
+    it 'parses vm information with description into event' do
+      event = JSON.parse(File.read(vm_with_description))
+      hash = described_class.event_to_hash(event, nil)
+
+      expect(hash).to include(
+        :source     => 'AZURE',
+        :timestamp  => '2017-11-21T19:47:07.5023866Z',
+        :message    => nil,
+        :ems_id     => nil,
+        :event_type => 'virtualMachines_deallocate_BeginRequest',
+        :full_data  => event,
+        :vm_ems_ref => "xyz\\bar\\microsoft.compute/virtualmachines\\another_vm"
+      )
+    end
+
+    it 'parses vm information with no description into event' do
+      event = JSON.parse(File.read(vm_no_description))
+      hash = described_class.event_to_hash(event, nil)
+
+      expect(hash).to include(
+        :source     => 'AZURE',
+        :timestamp  => '2017-11-21T19:44:42.5032036Z',
+        :message    => nil,
+        :ems_id     => nil,
+        :event_type => 'New Recommendation',
+        :full_data  => event,
+        :vm_ems_ref => "xyz\\foo\\microsoft.compute/virtualmachines\\my_vm1"
+      )
+    end
+
+    it 'parses non-vm information into event' do
+      event = JSON.parse(File.read(storage_account))
+      hash = described_class.event_to_hash(event, nil)
+
+      expect(hash).to include(
+        :source     => 'AZURE',
+        :timestamp  => '2017-11-20T08:24:46.8082029Z',
+        :message    => nil,
+        :ems_id     => nil,
+        :event_type => 'storageAccounts_listKeys_BeginRequest',
+        :full_data  => event,
+      )
+
+      expect(hash.key?(:vm_ems_ref)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
The event record returned by Azure contains lots of information that we aren't using. An individual json event record is about 2.5k. By selecting only the fields we need we can reduce memory usage down to less than 1k per record.

I've also added some specs for the EventParser.