### PR TITLE
Use include instead of have_attributes to avoid warnings

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack/orchestration_service_option_converter_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack/orchestration_service_option_converter_spec.rb
@@ -6,7 +6,7 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationServiceOptionCon
       let(:dialog_options) { {'dialog_resource_group' => 'abc', 'dialog_new_resource_group' => 'xyz'} }
 
       it "prefers resource_group over new_resource_group" do
-        expect(subject.stack_create_options).to have_attributes(:resource_group => 'abc')
+        expect(subject.stack_create_options).to include(:resource_group => 'abc')
       end
     end
 
@@ -14,7 +14,7 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationServiceOptionCon
       let(:dialog_options) { {'dialog_resource_group' => '', 'dialog_new_resource_group' => 'xyz'} }
 
       it "takes new_resource_group" do
-        expect(subject.stack_create_options).to have_attributes(:resource_group => 'xyz')
+        expect(subject.stack_create_options).to include(:resource_group => 'xyz')
       end
     end
   end


### PR DESCRIPTION
At the moment we're seeing a couple warnings when running the test suite, that are coming from our custom have_attributes definition. 

`WARNING: Use of 'have_attributes' with array access (:[]) is deprecated and will be removed shortly.
If you're matching attributes in hashes, use appropriate hash matchers instead ('include', 'eq').`

This PR just switches `have_attributes` to `include` for a couple specs.