### PR TITLE
Add the :all flag for events collection

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -182,12 +182,14 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
     storage_account   = storage_accounts(storage_conn).find { |account| account.name == storage_acct_name }
     storage_key       = storage_conn.list_account_keys(storage_account.name, storage_account.resource_group).fetch('key1')
 
-    # TODO: The following needs to pass :all => true for proper paging in case
-    #       the time range is > 1000 metrics, but there seems to be a bug in
-    #       continuation tokens when doing this.
+    filter = "PartitionKey eq '#{partition_key}' and CounterName eq '#{counter.name.value}' and Timestamp ge datetime'#{start_time.iso8601}' and Timestamp le datetime'#{end_time.iso8601}'"
+
+    fields = 'Timestamp,TIMESTAMP,Average'
+
     storage_account.table_data(table_name, storage_key,
-      :filter => "PartitionKey eq '#{partition_key}' and CounterName eq '#{counter.name.value}' and Timestamp ge datetime'#{start_time.iso8601}' and Timestamp le datetime'#{end_time.iso8601}'",
-      :select => "Timestamp,TIMESTAMP,Average"
+      :filter => filter,
+      :select => fields,
+      :all    => true
     )
   end
 


### PR DESCRIPTION
This addresses a TODO that was mentioned in the events collection code. At the moment we collect a maximum of 1000 events at a time. While it's unlikely that there are more than 1000 events in the given time window that we specify, it is possible.

The original issue mentioned was addressed in version 0.9.2 of the azure-armrest gem.