### PR TITLE
Add a guard when getting power status for a VM 

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -295,6 +295,8 @@ module ManageIQ::Providers
         view = @vmm.get_instance_view(instance.name, instance.resource_group)
         status = view.statuses.find { |s| s.code =~ %r{^PowerState/} }
         status.display_status if status
+      rescue ::Azure::Armrest::NotFoundException
+        'off' # Possible race condition caused by retirement deletion.
       end
 
       def process_os(instance)


### PR DESCRIPTION
When a VM is retired and a refresh happens within a short time of each other, a potential race condition can happen where the refresher attempts to collect the power status for a VM that's been deleted. When that happens an exception is raised.

This just adds a guard around the `power_status` method. If it hits a `NotFoundException` then that necessarily means it's been deleted and the power_status can be marked as 'off'.