### PR TITLE
Set api-version explicitly for discovery and regenerate cassettes

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -76,8 +76,10 @@ module ManageIQ::Providers::Azure::ManagerMixin
       known_emses = all_emses.select { |e| e.authentication_userid == clientid }
       known_ems_regions = known_emses.index_by(&:provider_region)
 
-      config     = raw_connect(clientid, clientkey, azure_tenant_id, subscription)
-      azure_res  = ::Azure::Armrest::ResourceService.new(config)
+      config = raw_connect(clientid, clientkey, azure_tenant_id, subscription)
+
+      azure_res = ::Azure::Armrest::ResourceService.new(config)
+      azure_res.api_version = Settings.ems.ems_azure.api_versions.resource.to_s
 
       azure_res.list_locations.each do |region|
         next if known_ems_regions.include?(region.name)

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_all_existing_records.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_all_existing_records.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 46f20bd5-d2fb-4239-a127-6e19b0442c00
+      - 4886ed41-d8ab-49cd-a329-95c4930b0c00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz3yWxKIZ0_eq_KFakhg5prEw8FY8Vp93Wuyx___16U7B3aCDvqJAKvw20HboSEc3lEJgPE12kupeqsVC_H4NhllI5IJ3SKyIX9eB66B_XuRfvxDy2-_WlgvdYrJ1rTwxFwSRlcoOZeLpGePCa9kmigrss7Y8X1MpZaBqI_PAJDA4gAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzcsGZJ-IXdFLvpbEXN__0WDF7MM9enovpPckSm5zE3Q4wZXuwQug6ZzWlG7PpMRX9cZShit2Xwid2YGCbmACyE8d-lCIiiW-L-RSdyOLi1VYKI7FEIr29C6sYJC4sS8eWVVkZ8tq8LFtIzKXGZJp9VeuwuB3tqJRjwU7SCpLm4F8gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 01 Dec 2017 22:28:09 GMT
+      - Thu, 07 Dec 2017 21:47:51 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1512170890","not_before":"1512166990","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1512686873","not_before":"1512682973","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:10 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -93,21 +93,21 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 60085ae9-2f29-40c2-aa97-60ed6edcb2b9
+      - 79150837-ae05-46d3-90a6-4c318b6af29f
       X-Ms-Correlation-Request-Id:
-      - 60085ae9-2f29-40c2-aa97-60ed6edcb2b9
+      - 79150837-ae05-46d3-90a6-4c318b6af29f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222810Z:60085ae9-2f29-40c2-aa97-60ed6edcb2b9
+      - WESTCENTRALUS:20171207T214753Z:79150837-ae05-46d3-90a6-4c318b6af29f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:09 GMT
+      - Thu, 07 Dec 2017 21:47:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:10 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -124,7 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -141,19 +141,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14917'
+      - '14991'
       X-Ms-Request-Id:
-      - fc010d1e-6e83-4a13-9840-b68b799989e1
+      - 1c90b457-c89f-486d-af83-f2534bceace8
       X-Ms-Correlation-Request-Id:
-      - fc010d1e-6e83-4a13-9840-b68b799989e1
+      - 1c90b457-c89f-486d-af83-f2534bceace8
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222811Z:fc010d1e-6e83-4a13-9840-b68b799989e1
+      - WESTCENTRALUS:20171207T214754Z:1c90b457-c89f-486d-af83-f2534bceace8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:11 GMT
+      - Thu, 07 Dec 2017 21:47:54 GMT
       Content-Length:
-      - '278554'
+      - '279208'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -260,7 +260,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -491,7 +491,7 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
-        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
         US","UK West","West India","Australia East","Brazil South","Canada East","East
@@ -614,92 +614,92 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","North
         Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
         South","Japan East","Japan West","North Europe","West Europe","Central India","South
@@ -816,7 +816,7 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
@@ -1459,7 +1459,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1606,7 +1606,8 @@ http_interactions:
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
@@ -1873,23 +1874,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1938,8 +1939,8 @@ http_interactions:
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
         Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
-        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"operations","locations":["Central
-        US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
@@ -2017,8 +2018,8 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -2030,18 +2031,18 @@ http_interactions:
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
@@ -2122,7 +2123,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:12 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/locations?api-version=2015-01-01
@@ -2139,7 +2140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2156,17 +2157,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14928'
+      - '14989'
       X-Ms-Request-Id:
-      - 4723354a-5915-4a23-bdbd-26597cd42210
+      - 24c785f4-acfe-4aaa-8196-494e2c27b911
       X-Ms-Correlation-Request-Id:
-      - 4723354a-5915-4a23-bdbd-26597cd42210
+      - 24c785f4-acfe-4aaa-8196-494e2c27b911
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222812Z:4723354a-5915-4a23-bdbd-26597cd42210
+      - WESTCENTRALUS:20171207T214755Z:24c785f4-acfe-4aaa-8196-494e2c27b911
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:12 GMT
+      - Thu, 07 Dec 2017 21:47:55 GMT
       Content-Length:
       - '4523'
     body:
@@ -2199,10 +2200,10 @@ http_interactions:
         Central","longitude":"126.9780","latitude":"37.5665"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/locations/koreasouth","name":"koreasouth","displayName":"Korea
         South","longitude":"129.0756","latitude":"35.1796"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:12 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2216,7 +2217,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2233,25 +2234,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5eb8d292-2ffe-451b-8db4-38e610d7d560
+      - a4e40ed9-dd0c-457b-bb71-efbdd287afe7
       X-Ms-Correlation-Request-Id:
-      - 5eb8d292-2ffe-451b-8db4-38e610d7d560
+      - a4e40ed9-dd0c-457b-bb71-efbdd287afe7
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222813Z:5eb8d292-2ffe-451b-8db4-38e610d7d560
+      - WESTCENTRALUS:20171207T214755Z:a4e40ed9-dd0c-457b-bb71-efbdd287afe7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:12 GMT
+      - Thu, 07 Dec 2017 21:47:55 GMT
       Content-Length:
-      - '549'
+      - '565'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:13 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2265,7 +2266,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2282,123 +2283,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 349b6ba8-fe17-4586-8394-5b880788f8b2
+      - 801089b4-652d-4b63-a1f0-a09a44b0f773
       X-Ms-Correlation-Request-Id:
-      - 349b6ba8-fe17-4586-8394-5b880788f8b2
+      - 801089b4-652d-4b63-a1f0-a09a44b0f773
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222814Z:349b6ba8-fe17-4586-8394-5b880788f8b2
+      - WESTCENTRALUS:20171207T214756Z:801089b4-652d-4b63-a1f0-a09a44b0f773
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:14 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8f4343a8-1e8c-4829-aec7-76f69eb47328
-      X-Ms-Correlation-Request-Id:
-      - 8f4343a8-1e8c-4829-aec7-76f69eb47328
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222815Z:8f4343a8-1e8c-4829-aec7-76f69eb47328
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:14 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 28163cec-8c04-491b-af8b-c723fdf23519
-      X-Ms-Correlation-Request-Id:
-      - 28163cec-8c04-491b-af8b-c723fdf23519
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222816Z:28163cec-8c04-491b-af8b-c723fdf23519
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:16 GMT
+      - Thu, 07 Dec 2017 21:47:55 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:16 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2412,7 +2315,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2429,25 +2332,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 07ed46ed-9bcb-48a1-be6c-a185a17f32fc
+      - 9adb977d-f1de-4eec-8f51-b30b3c9189ee
       X-Ms-Correlation-Request-Id:
-      - 07ed46ed-9bcb-48a1-be6c-a185a17f32fc
+      - 9adb977d-f1de-4eec-8f51-b30b3c9189ee
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222817Z:07ed46ed-9bcb-48a1-be6c-a185a17f32fc
+      - WESTCENTRALUS:20171207T214756Z:9adb977d-f1de-4eec-8f51-b30b3c9189ee
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:16 GMT
+      - Thu, 07 Dec 2017 21:47:56 GMT
       Content-Length:
-      - '550'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:17 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:57 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2461,7 +2364,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2478,25 +2381,123 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6225fc50-b4d2-485e-899f-15adb087b63e
+      - 11bf72d7-6d3f-4eb5-9277-e9d30307f5f5
       X-Ms-Correlation-Request-Id:
-      - 6225fc50-b4d2-485e-899f-15adb087b63e
+      - 11bf72d7-6d3f-4eb5-9277-e9d30307f5f5
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222817Z:6225fc50-b4d2-485e-899f-15adb087b63e
+      - WESTCENTRALUS:20171207T214757Z:11bf72d7-6d3f-4eb5-9277-e9d30307f5f5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:17 GMT
+      - Thu, 07 Dec 2017 21:47:57 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f5eb45e9-5b0b-4bb6-8e4e-dc55e6855bc7
+      X-Ms-Correlation-Request-Id:
+      - f5eb45e9-5b0b-4bb6-8e4e-dc55e6855bc7
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214757Z:f5eb45e9-5b0b-4bb6-8e4e-dc55e6855bc7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:57 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 38ca44f7-f411-46dd-a810-d657b52969d5
+      X-Ms-Correlation-Request-Id:
+      - 38ca44f7-f411-46dd-a810-d657b52969d5
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214758Z:38ca44f7-f411-46dd-a810-d657b52969d5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:57 GMT
       Content-Length:
       - '1104'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2","name":"jf-metrics-2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3","name":"jf-metrics-3","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1","name":"miqazure-oraclelinux1","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2","name":"miqazure-oraclelinux2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"false"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:17 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:58 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2510,7 +2511,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2527,25 +2528,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0dac84d7-fa6f-416d-95d6-dd6b9ee8d661
+      - 485caba8-c106-470e-8257-4866eaaa1cd9
       X-Ms-Correlation-Request-Id:
-      - 0dac84d7-fa6f-416d-95d6-dd6b9ee8d661
+      - 485caba8-c106-470e-8257-4866eaaa1cd9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222818Z:0dac84d7-fa6f-416d-95d6-dd6b9ee8d661
+      - WESTCENTRALUS:20171207T214758Z:485caba8-c106-470e-8257-4866eaaa1cd9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:18 GMT
+      - Thu, 07 Dec 2017 21:47:58 GMT
       Content-Length:
-      - '548'
+      - '564'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:18 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:58 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2559,7 +2560,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2576,123 +2577,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a74e5ae9-1e9d-4d75-875b-812e6247bc40
+      - 2c68bc29-20dc-4c1f-8c3d-fa6699fc8183
       X-Ms-Correlation-Request-Id:
-      - a74e5ae9-1e9d-4d75-875b-812e6247bc40
+      - 2c68bc29-20dc-4c1f-8c3d-fa6699fc8183
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222819Z:a74e5ae9-1e9d-4d75-875b-812e6247bc40
+      - WESTCENTRALUS:20171207T214759Z:2c68bc29-20dc-4c1f-8c3d-fa6699fc8183
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:19 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:19 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0aa713b8-67b7-4aad-ba0e-1961c0a84ea2
-      X-Ms-Correlation-Request-Id:
-      - 0aa713b8-67b7-4aad-ba0e-1961c0a84ea2
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222820Z:0aa713b8-67b7-4aad-ba0e-1961c0a84ea2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:19 GMT
-      Content-Length:
-      - '555'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:20 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e8181a7d-fb1e-40ff-b101-0071708ab56a
-      X-Ms-Correlation-Request-Id:
-      - e8181a7d-fb1e-40ff-b101-0071708ab56a
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222821Z:e8181a7d-fb1e-40ff-b101-0071708ab56a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:20 GMT
+      - Thu, 07 Dec 2017 21:47:58 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:21 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:59 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2706,7 +2609,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2723,25 +2626,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4b34ecbf-3ebd-4978-a3a7-37ee0e36e428
+      - 81af6af5-97e7-4310-9734-575ae843cab6
       X-Ms-Correlation-Request-Id:
-      - 4b34ecbf-3ebd-4978-a3a7-37ee0e36e428
+      - 81af6af5-97e7-4310-9734-575ae843cab6
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222821Z:4b34ecbf-3ebd-4978-a3a7-37ee0e36e428
+      - WESTCENTRALUS:20171207T214759Z:81af6af5-97e7-4310-9734-575ae843cab6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:21 GMT
+      - Thu, 07 Dec 2017 21:47:58 GMT
       Content-Length:
-      - '555'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:22 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:59 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2755,7 +2658,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2772,123 +2675,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f8b6287c-8de7-48a5-8c1d-b92e56d55243
+      - 819dab3d-bfbd-4feb-ad04-24c45de4fd23
       X-Ms-Correlation-Request-Id:
-      - f8b6287c-8de7-48a5-8c1d-b92e56d55243
+      - 819dab3d-bfbd-4feb-ad04-24c45de4fd23
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222822Z:f8b6287c-8de7-48a5-8c1d-b92e56d55243
+      - WESTCENTRALUS:20171207T214759Z:819dab3d-bfbd-4feb-ad04-24c45de4fd23
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:21 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a22ff6a1-9657-491a-a957-6ec0ad19c00b
-      X-Ms-Correlation-Request-Id:
-      - a22ff6a1-9657-491a-a957-6ec0ad19c00b
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222823Z:a22ff6a1-9657-491a-a957-6ec0ad19c00b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:23 GMT
-      Content-Length:
-      - '552'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fcbdb4a9-a720-4989-aa55-d03b5cb174c8
-      X-Ms-Correlation-Request-Id:
-      - fcbdb4a9-a720-4989-aa55-d03b5cb174c8
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222824Z:fcbdb4a9-a720-4989-aa55-d03b5cb174c8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:23 GMT
+      - Thu, 07 Dec 2017 21:47:59 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:24 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:59 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2902,7 +2707,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2919,25 +2724,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 47e6b708-3d34-4606-8df2-3a737eb5917a
+      - 045f7159-23dc-4439-8444-02965e592aa9
       X-Ms-Correlation-Request-Id:
-      - 47e6b708-3d34-4606-8df2-3a737eb5917a
+      - 045f7159-23dc-4439-8444-02965e592aa9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222824Z:47e6b708-3d34-4606-8df2-3a737eb5917a
+      - WESTCENTRALUS:20171207T214800Z:045f7159-23dc-4439-8444-02965e592aa9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:24 GMT
+      - Thu, 07 Dec 2017 21:48:00 GMT
       Content-Length:
-      - '551'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:24 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:00 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2951,7 +2756,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -2968,123 +2773,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d1556ca0-9c36-4d3a-94cd-77935d4fdc0d
+      - d2adc8af-ce4c-4a08-a31a-631a1dfae2d2
       X-Ms-Correlation-Request-Id:
-      - d1556ca0-9c36-4d3a-94cd-77935d4fdc0d
+      - d2adc8af-ce4c-4a08-a31a-631a1dfae2d2
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222825Z:d1556ca0-9c36-4d3a-94cd-77935d4fdc0d
+      - WESTCENTRALUS:20171207T214800Z:d2adc8af-ce4c-4a08-a31a-631a1dfae2d2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:24 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f22226ab-ac7e-4693-b0e8-ecefb5780eeb
-      X-Ms-Correlation-Request-Id:
-      - f22226ab-ac7e-4693-b0e8-ecefb5780eeb
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222826Z:f22226ab-ac7e-4693-b0e8-ecefb5780eeb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:25 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2e0c5cd0-05b5-4913-b5c8-0c4ab941ee72
-      X-Ms-Correlation-Request-Id:
-      - 2e0c5cd0-05b5-4913-b5c8-0c4ab941ee72
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222827Z:2e0c5cd0-05b5-4913-b5c8-0c4ab941ee72
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:26 GMT
+      - Thu, 07 Dec 2017 21:48:00 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:27 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:00 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3098,7 +2805,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -3115,25 +2822,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ef93cbb8-e123-4564-a43b-47c0bfc1163b
+      - a7ace45b-7a43-456d-ae79-77752e08fead
       X-Ms-Correlation-Request-Id:
-      - ef93cbb8-e123-4564-a43b-47c0bfc1163b
+      - a7ace45b-7a43-456d-ae79-77752e08fead
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222827Z:ef93cbb8-e123-4564-a43b-47c0bfc1163b
+      - WESTCENTRALUS:20171207T214801Z:a7ace45b-7a43-456d-ae79-77752e08fead
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:27 GMT
+      - Thu, 07 Dec 2017 21:48:00 GMT
       Content-Length:
-      - '550'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:28 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3147,7 +2854,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -3164,123 +2871,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e7d13de9-01f7-441a-9071-f2ec9321bf7f
+      - 2d908de6-f77a-4621-97e4-0cd20064e90a
       X-Ms-Correlation-Request-Id:
-      - e7d13de9-01f7-441a-9071-f2ec9321bf7f
+      - 2d908de6-f77a-4621-97e4-0cd20064e90a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222828Z:e7d13de9-01f7-441a-9071-f2ec9321bf7f
+      - WESTCENTRALUS:20171207T214801Z:2d908de6-f77a-4621-97e4-0cd20064e90a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:27 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e3c53830-14c3-40ca-b3bb-e7064c336fdd
-      X-Ms-Correlation-Request-Id:
-      - e3c53830-14c3-40ca-b3bb-e7064c336fdd
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222829Z:e3c53830-14c3-40ca-b3bb-e7064c336fdd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:29 GMT
-      Content-Length:
-      - '552'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 3eb52122-3adb-4e8b-92b4-72d59f26c5e6
-      X-Ms-Correlation-Request-Id:
-      - 3eb52122-3adb-4e8b-92b4-72d59f26c5e6
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222830Z:3eb52122-3adb-4e8b-92b4-72d59f26c5e6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:29 GMT
+      - Thu, 07 Dec 2017 21:48:00 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:30 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3294,7 +2903,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -3311,25 +2920,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8b0694b0-d0cb-4e99-bacd-29bf3bd3d8d6
+      - 0a096cbc-a213-4373-980e-9d0095e196da
       X-Ms-Correlation-Request-Id:
-      - 8b0694b0-d0cb-4e99-bacd-29bf3bd3d8d6
+      - 0a096cbc-a213-4373-980e-9d0095e196da
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222831Z:8b0694b0-d0cb-4e99-bacd-29bf3bd3d8d6
+      - WESTCENTRALUS:20171207T214802Z:0a096cbc-a213-4373-980e-9d0095e196da
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:31 GMT
+      - Thu, 07 Dec 2017 21:48:01 GMT
       Content-Length:
-      - '554'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:31 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3343,7 +2952,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -3360,123 +2969,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 404fbaf6-3344-47ac-9ec5-bdf789198f48
+      - ca040de4-d806-4394-98dc-a22858f787ce
       X-Ms-Correlation-Request-Id:
-      - 404fbaf6-3344-47ac-9ec5-bdf789198f48
+      - ca040de4-d806-4394-98dc-a22858f787ce
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222832Z:404fbaf6-3344-47ac-9ec5-bdf789198f48
+      - WESTCENTRALUS:20171207T214802Z:ca040de4-d806-4394-98dc-a22858f787ce
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:32 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - eb731a84-4219-4234-b546-55d2af990e98
-      X-Ms-Correlation-Request-Id:
-      - eb731a84-4219-4234-b546-55d2af990e98
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222832Z:eb731a84-4219-4234-b546-55d2af990e98
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:32 GMT
-      Content-Length:
-      - '559'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fa260c39-3c58-409d-8ff6-19979be88dba
-      X-Ms-Correlation-Request-Id:
-      - fa260c39-3c58-409d-8ff6-19979be88dba
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222833Z:fa260c39-3c58-409d-8ff6-19979be88dba
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:33 GMT
+      - Thu, 07 Dec 2017 21:48:02 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:33 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3490,7 +3001,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -3507,25 +3018,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7b96e12c-79d7-41de-a072-425cbee1d565
+      - '093d3efa-3831-4a07-9d7e-4f4d7badb561'
       X-Ms-Correlation-Request-Id:
-      - 7b96e12c-79d7-41de-a072-425cbee1d565
+      - '093d3efa-3831-4a07-9d7e-4f4d7badb561'
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222833Z:7b96e12c-79d7-41de-a072-425cbee1d565
+      - WESTCENTRALUS:20171207T214803Z:093d3efa-3831-4a07-9d7e-4f4d7badb561
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:33 GMT
+      - Thu, 07 Dec 2017 21:48:02 GMT
       Content-Length:
-      - '551'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:34 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:03 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3539,7 +3050,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -3556,123 +3067,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 295b3569-7ced-40fd-ac81-d7d4a14a83ac
+      - dcbc19fb-bfd8-43a5-a280-177cbaa06a65
       X-Ms-Correlation-Request-Id:
-      - 295b3569-7ced-40fd-ac81-d7d4a14a83ac
+      - dcbc19fb-bfd8-43a5-a280-177cbaa06a65
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222834Z:295b3569-7ced-40fd-ac81-d7d4a14a83ac
+      - WESTCENTRALUS:20171207T214803Z:dcbc19fb-bfd8-43a5-a280-177cbaa06a65
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:33 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b4912bea-23c0-4dbc-b45d-f92b82d17ccd
-      X-Ms-Correlation-Request-Id:
-      - b4912bea-23c0-4dbc-b45d-f92b82d17ccd
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222835Z:b4912bea-23c0-4dbc-b45d-f92b82d17ccd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:34 GMT
-      Content-Length:
-      - '553'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2fe23304-9931-468d-ab41-7874b0bf9b92
-      X-Ms-Correlation-Request-Id:
-      - 2fe23304-9931-468d-ab41-7874b0bf9b92
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222835Z:2fe23304-9931-468d-ab41-7874b0bf9b92
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:35 GMT
+      - Thu, 07 Dec 2017 21:48:02 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:35 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:03 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3686,7 +3099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -3703,25 +3116,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e7f7bca1-49d3-4607-88b4-94db4aacba58
+      - 34d349c2-ec70-4e66-a137-b0a4f991df39
       X-Ms-Correlation-Request-Id:
-      - e7f7bca1-49d3-4607-88b4-94db4aacba58
+      - 34d349c2-ec70-4e66-a137-b0a4f991df39
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222836Z:e7f7bca1-49d3-4607-88b4-94db4aacba58
+      - WESTCENTRALUS:20171207T214803Z:34d349c2-ec70-4e66-a137-b0a4f991df39
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:35 GMT
+      - Thu, 07 Dec 2017 21:48:03 GMT
       Content-Length:
-      - '550'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:36 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3735,7 +3148,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -3752,123 +3165,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f43f45e4-c3d4-4139-9548-1aec9e1402df
+      - ec90aafe-b3d2-4572-a079-abc1abcca315
       X-Ms-Correlation-Request-Id:
-      - f43f45e4-c3d4-4139-9548-1aec9e1402df
+      - ec90aafe-b3d2-4572-a079-abc1abcca315
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222837Z:f43f45e4-c3d4-4139-9548-1aec9e1402df
+      - WESTCENTRALUS:20171207T214804Z:ec90aafe-b3d2-4572-a079-abc1abcca315
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:36 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 589a7dbb-9e0e-4802-aa76-8c5ca9cd5639
-      X-Ms-Correlation-Request-Id:
-      - 589a7dbb-9e0e-4802-aa76-8c5ca9cd5639
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222837Z:589a7dbb-9e0e-4802-aa76-8c5ca9cd5639
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:37 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5d61ef3a-b3fc-4244-b8ca-5c9866156e81
-      X-Ms-Correlation-Request-Id:
-      - 5d61ef3a-b3fc-4244-b8ca-5c9866156e81
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222838Z:5d61ef3a-b3fc-4244-b8ca-5c9866156e81
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:37 GMT
+      - Thu, 07 Dec 2017 21:48:03 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:38 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3882,7 +3197,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -3899,25 +3214,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 00d4f5ca-ef2e-4941-b990-a3c54078e1e2
+      - bd4857aa-cfa4-4068-b79b-f104ac724d29
       X-Ms-Correlation-Request-Id:
-      - 00d4f5ca-ef2e-4941-b990-a3c54078e1e2
+      - bd4857aa-cfa4-4068-b79b-f104ac724d29
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222838Z:00d4f5ca-ef2e-4941-b990-a3c54078e1e2
+      - WESTCENTRALUS:20171207T214804Z:bd4857aa-cfa4-4068-b79b-f104ac724d29
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:38 GMT
+      - Thu, 07 Dec 2017 21:48:03 GMT
       Content-Length:
-      - '551'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:38 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3931,7 +3246,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -3948,123 +3263,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - be496acc-3b95-4750-8bf7-4f0a0da12ec6
+      - 464d6ca3-0b65-4621-98d9-a6b2c634d182
       X-Ms-Correlation-Request-Id:
-      - be496acc-3b95-4750-8bf7-4f0a0da12ec6
+      - 464d6ca3-0b65-4621-98d9-a6b2c634d182
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222839Z:be496acc-3b95-4750-8bf7-4f0a0da12ec6
+      - WESTCENTRALUS:20171207T214805Z:464d6ca3-0b65-4621-98d9-a6b2c634d182
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:38 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5c08c65f-0e12-42d8-a780-f49deac95698
-      X-Ms-Correlation-Request-Id:
-      - 5c08c65f-0e12-42d8-a780-f49deac95698
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222839Z:5c08c65f-0e12-42d8-a780-f49deac95698
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:39 GMT
-      Content-Length:
-      - '548'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 784f5367-a004-4ea7-b1c9-6651bba3cb21
-      X-Ms-Correlation-Request-Id:
-      - 784f5367-a004-4ea7-b1c9-6651bba3cb21
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222840Z:784f5367-a004-4ea7-b1c9-6651bba3cb21
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:40 GMT
+      - Thu, 07 Dec 2017 21:48:04 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:40 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4078,7 +3295,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -4095,25 +3312,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f33a2e4e-efbc-4d61-bc8b-dcfecca4b24f
+      - 7dc92480-b80d-4ba6-bad9-d6a239ccb0c8
       X-Ms-Correlation-Request-Id:
-      - f33a2e4e-efbc-4d61-bc8b-dcfecca4b24f
+      - 7dc92480-b80d-4ba6-bad9-d6a239ccb0c8
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222840Z:f33a2e4e-efbc-4d61-bc8b-dcfecca4b24f
+      - WESTCENTRALUS:20171207T214805Z:7dc92480-b80d-4ba6-bad9-d6a239ccb0c8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:40 GMT
+      - Thu, 07 Dec 2017 21:48:05 GMT
       Content-Length:
-      - '547'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:40 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4127,7 +3344,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -4144,123 +3361,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd347c89-b877-48a6-b811-609563fc8225
+      - 9318ac5f-2437-418d-9ecf-55d2b5951ac5
       X-Ms-Correlation-Request-Id:
-      - bd347c89-b877-48a6-b811-609563fc8225
+      - 9318ac5f-2437-418d-9ecf-55d2b5951ac5
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222841Z:bd347c89-b877-48a6-b811-609563fc8225
+      - WESTCENTRALUS:20171207T214805Z:9318ac5f-2437-418d-9ecf-55d2b5951ac5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:41 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 556b3faf-59ba-4ab3-a30e-5a66eece89fd
-      X-Ms-Correlation-Request-Id:
-      - 556b3faf-59ba-4ab3-a30e-5a66eece89fd
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222842Z:556b3faf-59ba-4ab3-a30e-5a66eece89fd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:42 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fdd58d5b-7227-4625-b40b-210100ffa76a
-      X-Ms-Correlation-Request-Id:
-      - fdd58d5b-7227-4625-b40b-210100ffa76a
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222842Z:fdd58d5b-7227-4625-b40b-210100ffa76a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:42 GMT
+      - Thu, 07 Dec 2017 21:48:05 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:42 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:06 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4274,7 +3393,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -4291,25 +3410,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2a7b4c0b-7f6d-403d-b398-94b42c62a598
+      - 966a69d4-0b04-4a85-b787-9a0b609611c6
       X-Ms-Correlation-Request-Id:
-      - 2a7b4c0b-7f6d-403d-b398-94b42c62a598
+      - 966a69d4-0b04-4a85-b787-9a0b609611c6
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222843Z:2a7b4c0b-7f6d-403d-b398-94b42c62a598
+      - WESTCENTRALUS:20171207T214806Z:966a69d4-0b04-4a85-b787-9a0b609611c6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:42 GMT
+      - Thu, 07 Dec 2017 21:48:05 GMT
       Content-Length:
-      - '548'
+      - '575'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:43 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:06 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4323,7 +3442,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -4340,123 +3459,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ac530970-77c6-4a15-a60e-2c52eed39fb8
+      - af025679-ba4d-4909-8ac3-0fbd6461ffcb
       X-Ms-Correlation-Request-Id:
-      - ac530970-77c6-4a15-a60e-2c52eed39fb8
+      - af025679-ba4d-4909-8ac3-0fbd6461ffcb
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222844Z:ac530970-77c6-4a15-a60e-2c52eed39fb8
+      - WESTCENTRALUS:20171207T214806Z:af025679-ba4d-4909-8ac3-0fbd6461ffcb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:43 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0c3c3cb2-53ff-4d37-b1b6-1a93cffddead
-      X-Ms-Correlation-Request-Id:
-      - 0c3c3cb2-53ff-4d37-b1b6-1a93cffddead
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222844Z:0c3c3cb2-53ff-4d37-b1b6-1a93cffddead
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:43 GMT
-      Content-Length:
-      - '553'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - cf867a5a-8b76-45ab-909a-f4e0e5a5f1f1
-      X-Ms-Correlation-Request-Id:
-      - cf867a5a-8b76-45ab-909a-f4e0e5a5f1f1
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222845Z:cf867a5a-8b76-45ab-909a-f4e0e5a5f1f1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:44 GMT
+      - Thu, 07 Dec 2017 21:48:05 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:45 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:06 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4470,7 +3491,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -4487,25 +3508,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - db8c27e5-8945-4970-8f57-d2666c4001a7
+      - c5947e8c-dc17-40b3-b28d-0d5e87a848d9
       X-Ms-Correlation-Request-Id:
-      - db8c27e5-8945-4970-8f57-d2666c4001a7
+      - c5947e8c-dc17-40b3-b28d-0d5e87a848d9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222845Z:db8c27e5-8945-4970-8f57-d2666c4001a7
+      - WESTCENTRALUS:20171207T214807Z:c5947e8c-dc17-40b3-b28d-0d5e87a848d9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:45 GMT
+      - Thu, 07 Dec 2017 21:48:06 GMT
       Content-Length:
-      - '551'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:46 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4519,7 +3540,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5OTAsIm5iZiI6MTUxMjE2Njk5MCwiZXhwIjoxNTEyMTcwODkwLCJhaW8iOiJZMk5nWU1pNGNFZE54eWlWUzA1VGpmTlZiRk1aQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMVF2eVJ2dlNPVUtoSjI0WnNFUXNBQSIsInZlciI6IjEuMCJ9.pikNbjqxhn_XFJkXRjBHysGjDTGs5X6zC-AHZT3-82uYWqJP342_9pQVfapcn-8NR4oVopjdDRxWJrZXLl0hQHy4vO6h2Tz-I5RgPji3p2eQNu-c-1k9YSYpD_A_NIkKKwma2Mh3AbYPP7FKPsa2U0Uf2dTJgzhanEhtS5nZDSETUOC3sCSyz6COVLPYe3a4p2HgnGs2TyfW1-dAfCFHwtoSjOKPfuuAEhrlWMf9w1cgwi1mg0M9slH4Cjp59MtwKgy8knVvDHitBYEw9dubiLxb-323gfk3a0z5hNpFkhc60xINATRPbatIw-bgQyHGeZVz_361cAPXvjpvvEsFbg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
   response:
     status:
       code: 200
@@ -4536,20 +3557,1000 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 54c4a552-2869-453b-9f68-9aabb3912b37
+      - 0fb5384d-e6b4-498e-9042-841d898aaf5b
       X-Ms-Correlation-Request-Id:
-      - 54c4a552-2869-453b-9f68-9aabb3912b37
+      - 0fb5384d-e6b4-498e-9042-841d898aaf5b
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222846Z:54c4a552-2869-453b-9f68-9aabb3912b37
+      - WESTCENTRALUS:20171207T214807Z:0fb5384d-e6b4-498e-9042-841d898aaf5b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:46 GMT
+      - Thu, 07 Dec 2017 21:48:06 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:46 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c3a16799-3eac-4246-8bac-93e891eca629
+      X-Ms-Correlation-Request-Id:
+      - c3a16799-3eac-4246-8bac-93e891eca629
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214807Z:c3a16799-3eac-4246-8bac-93e891eca629
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:06 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6ce7bb80-efa1-4e2d-ab8c-64a9d4c0f33c
+      X-Ms-Correlation-Request-Id:
+      - 6ce7bb80-efa1-4e2d-ab8c-64a9d4c0f33c
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214808Z:6ce7bb80-efa1-4e2d-ab8c-64a9d4c0f33c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:07 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9a6b058a-2dae-43a6-875b-a10b9b680d8d
+      X-Ms-Correlation-Request-Id:
+      - 9a6b058a-2dae-43a6-875b-a10b9b680d8d
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214808Z:9a6b058a-2dae-43a6-875b-a10b9b680d8d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:08 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0c2f6feb-419e-4536-a54f-c8611fb91b00
+      X-Ms-Correlation-Request-Id:
+      - 0c2f6feb-419e-4536-a54f-c8611fb91b00
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214809Z:0c2f6feb-419e-4536-a54f-c8611fb91b00
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:08 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - '090d7b0b-0a2b-4ea3-a967-aa8c71fc17d5'
+      X-Ms-Correlation-Request-Id:
+      - '090d7b0b-0a2b-4ea3-a967-aa8c71fc17d5'
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214809Z:090d7b0b-0a2b-4ea3-a967-aa8c71fc17d5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:09 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c7455aa0-de10-4e6c-8f30-2c124b9f0744
+      X-Ms-Correlation-Request-Id:
+      - c7455aa0-de10-4e6c-8f30-2c124b9f0744
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214809Z:c7455aa0-de10-4e6c-8f30-2c124b9f0744
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:09 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f2743870-867f-4f5b-a8fc-b101782ad77a
+      X-Ms-Correlation-Request-Id:
+      - f2743870-867f-4f5b-a8fc-b101782ad77a
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214810Z:f2743870-867f-4f5b-a8fc-b101782ad77a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:09 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 44573ee2-27fd-44dc-a7fa-6cb586ac3455
+      X-Ms-Correlation-Request-Id:
+      - 44573ee2-27fd-44dc-a7fa-6cb586ac3455
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214810Z:44573ee2-27fd-44dc-a7fa-6cb586ac3455
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:09 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 07b158f3-fd4e-4233-8685-7e2741518ad3
+      X-Ms-Correlation-Request-Id:
+      - 07b158f3-fd4e-4233-8685-7e2741518ad3
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214811Z:07b158f3-fd4e-4233-8685-7e2741518ad3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:11 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 10032bff-4a96-4c5d-bac2-aff0f2001136
+      X-Ms-Correlation-Request-Id:
+      - 10032bff-4a96-4c5d-bac2-aff0f2001136
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214811Z:10032bff-4a96-4c5d-bac2-aff0f2001136
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:10 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8992c9da-b478-4802-9bf9-bdca681c896c
+      X-Ms-Correlation-Request-Id:
+      - 8992c9da-b478-4802-9bf9-bdca681c896c
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214811Z:8992c9da-b478-4802-9bf9-bdca681c896c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:11 GMT
+      Content-Length:
+      - '563'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - cc63b5b3-8622-4287-8e3e-b2e004f33d35
+      X-Ms-Correlation-Request-Id:
+      - cc63b5b3-8622-4287-8e3e-b2e004f33d35
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214812Z:cc63b5b3-8622-4287-8e3e-b2e004f33d35
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:11 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 53eb5118-8930-46ec-a33e-885e8eca442b
+      X-Ms-Correlation-Request-Id:
+      - 53eb5118-8930-46ec-a33e-885e8eca442b
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214812Z:53eb5118-8930-46ec-a33e-885e8eca442b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:12 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c3f611bd-96e4-4c5e-9936-3fec25e39dfc
+      X-Ms-Correlation-Request-Id:
+      - c3f611bd-96e4-4c5e-9936-3fec25e39dfc
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214813Z:c3f611bd-96e4-4c5e-9936-3fec25e39dfc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:12 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 51d626c9-7cf3-408c-bb48-8f23f13b6fb4
+      X-Ms-Correlation-Request-Id:
+      - 51d626c9-7cf3-408c-bb48-8f23f13b6fb4
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214813Z:51d626c9-7cf3-408c-bb48-8f23f13b6fb4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:12 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:13 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - eaccdba0-747a-46ff-88db-342bbf3d1c12
+      X-Ms-Correlation-Request-Id:
+      - eaccdba0-747a-46ff-88db-342bbf3d1c12
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214813Z:eaccdba0-747a-46ff-88db-342bbf3d1c12
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:13 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6991d987-a8c8-4298-8fb4-b1cbd1ad064d
+      X-Ms-Correlation-Request-Id:
+      - 6991d987-a8c8-4298-8fb4-b1cbd1ad064d
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214814Z:6991d987-a8c8-4298-8fb4-b1cbd1ad064d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:14 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4192573a-2d19-460f-b95f-cca30d231026
+      X-Ms-Correlation-Request-Id:
+      - 4192573a-2d19-460f-b95f-cca30d231026
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214814Z:4192573a-2d19-460f-b95f-cca30d231026
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:13 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ae289507-757d-4cb9-891d-46559248ec4f
+      X-Ms-Correlation-Request-Id:
+      - ae289507-757d-4cb9-891d-46559248ec4f
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214815Z:ae289507-757d-4cb9-891d-46559248ec4f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:14 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NzMsIm5iZiI6MTUxMjY4Mjk3MywiZXhwIjoxNTEyNjg2ODczLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUWUyR1NLdll6VW1qS1pYRWt3c01BQSIsInZlciI6IjEuMCJ9.ab4as_dstFA09TjgzN63GrpSVCeJd59H8DF9WkeHXHDe_VaoWlnXNnQIok2-YsJPIkWaws6ynDJmAbqAoJ0YCD_X_DztYNkS7Pg-yzGKkm85FHasTt4bBybRthhFGB7w2imh461tl-cNN6MTRMl71QX3VEPG4z__2X9tpPTf-NmDeAF3VacxZ9hKTInJb5jrvBBjVFzCSh4JIRTA3IFh_IWU1bOgszV7y1Vfi_ywO7KIhJ7tRPf9w09EvSJxSltg5PR3OoRqwfmILP0u1BAsnP4-WcqBdcdiTteFoplw7koPeqryZJsgAUFmn4E4H58O_axoTpRsTtRgxKmungxoLw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 67354d2e-cd90-476a-be8c-9fae17519e20
+      X-Ms-Correlation-Request-Id:
+      - 67354d2e-cd90-476a-be8c-9fae17519e20
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214815Z:67354d2e-cd90-476a-be8c-9fae17519e20
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:14 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:15 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_no_existing_records.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_no_existing_records.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 7011b515-cdad-4e10-abfa-57cd45352e00
+      - 192af9db-d061-4538-af12-45a7ce420c00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzymkFv1Avl84cDFS5sHe77lUncnPYNzPt81e1R1n2WtrqyOGhyylZIP_32xC8Xtfh4fq98AWLeNF4kzHUNbA5WzpE_OUdbxFc-jj4mKtqGj8fxwKOfI-SkMYrN8E_yXFG0q-Jg1WSTUhhNFpkb3NUB_ffGypExVmmKr5IabRq3a8gAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHza_TYHfuVva_TWlsFfi0rFn4EHn4wimx24YowCSSooJezkd7ySEsyBd1WT3nUE1CEaKKxWIk3GeYNxrSG-Tz6tOvC1DvzB7yBZjHT1bm_WWOyL-FPQhtNXFvNX225N-C0_e33K8wd1hLUOM8b4TVMNIizQEIWfh0im9t0VOISq_IgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 01 Dec 2017 22:27:30 GMT
+      - Thu, 07 Dec 2017 21:47:26 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1512170850","not_before":"1512166950","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1512686849","not_before":"1512682949","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:30 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:29 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -91,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
+      - '14999'
       X-Ms-Request-Id:
-      - 38dfe1ae-bc27-4b19-89ad-acd9c9528fac
+      - 2d553908-615d-4867-8f0c-3f6f6bf08ff9
       X-Ms-Correlation-Request-Id:
-      - 38dfe1ae-bc27-4b19-89ad-acd9c9528fac
+      - 2d553908-615d-4867-8f0c-3f6f6bf08ff9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222731Z:38dfe1ae-bc27-4b19-89ad-acd9c9528fac
+      - WESTCENTRALUS:20171207T214729Z:2d553908-615d-4867-8f0c-3f6f6bf08ff9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:30 GMT
+      - Thu, 07 Dec 2017 21:47:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:31 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:29 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -124,7 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -141,19 +141,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14927'
+      - '14979'
       X-Ms-Request-Id:
-      - ff1f6e43-f62f-4550-b712-9a299baa25ce
+      - d48f649d-589b-46db-86f6-558621e20204
       X-Ms-Correlation-Request-Id:
-      - ff1f6e43-f62f-4550-b712-9a299baa25ce
+      - d48f649d-589b-46db-86f6-558621e20204
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222732Z:ff1f6e43-f62f-4550-b712-9a299baa25ce
+      - WESTCENTRALUS:20171207T214730Z:d48f649d-589b-46db-86f6-558621e20204
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:32 GMT
+      - Thu, 07 Dec 2017 21:47:29 GMT
       Content-Length:
-      - '278554'
+      - '279208'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -260,7 +260,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -491,7 +491,7 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
-        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
         US","UK West","West India","Australia East","Brazil South","Canada East","East
@@ -614,92 +614,92 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","North
         Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
         South","Japan East","Japan West","North Europe","West Europe","Central India","South
@@ -816,7 +816,7 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
@@ -1459,7 +1459,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1606,7 +1606,8 @@ http_interactions:
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
@@ -1873,23 +1874,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1938,8 +1939,8 @@ http_interactions:
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
         Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
-        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"operations","locations":["Central
-        US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
@@ -2017,8 +2018,8 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -2030,18 +2031,18 @@ http_interactions:
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
@@ -2122,7 +2123,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:32 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/locations?api-version=2015-01-01
@@ -2139,7 +2140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2156,17 +2157,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14913'
+      - '13782'
       X-Ms-Request-Id:
-      - 121a9e98-edff-4181-8313-a857d53a3fc7
+      - 16e8b295-c4b3-4fa0-ba01-e0d5de355f28
       X-Ms-Correlation-Request-Id:
-      - 121a9e98-edff-4181-8313-a857d53a3fc7
+      - 16e8b295-c4b3-4fa0-ba01-e0d5de355f28
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222732Z:121a9e98-edff-4181-8313-a857d53a3fc7
+      - WESTCENTRALUS:20171207T214730Z:16e8b295-c4b3-4fa0-ba01-e0d5de355f28
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:32 GMT
+      - Thu, 07 Dec 2017 21:47:30 GMT
       Content-Length:
       - '4523'
     body:
@@ -2199,10 +2200,10 @@ http_interactions:
         Central","longitude":"126.9780","latitude":"37.5665"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/locations/koreasouth","name":"koreasouth","displayName":"Korea
         South","longitude":"129.0756","latitude":"35.1796"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:32 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:30 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2216,7 +2217,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2233,25 +2234,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d05fab9b-ef1e-48f8-9110-a32850c3c35a
+      - d773e8f1-473d-4a8a-85f2-32ce65a50247
       X-Ms-Correlation-Request-Id:
-      - d05fab9b-ef1e-48f8-9110-a32850c3c35a
+      - d773e8f1-473d-4a8a-85f2-32ce65a50247
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222733Z:d05fab9b-ef1e-48f8-9110-a32850c3c35a
+      - WESTCENTRALUS:20171207T214731Z:d773e8f1-473d-4a8a-85f2-32ce65a50247
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:32 GMT
+      - Thu, 07 Dec 2017 21:47:30 GMT
       Content-Length:
-      - '549'
+      - '565'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:33 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:31 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2265,7 +2266,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2282,123 +2283,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2ee65053-daf5-4986-a6f7-ade68e7fe9c9
+      - 8afa0cae-0c7d-400c-9fdf-4d3a1d1ff115
       X-Ms-Correlation-Request-Id:
-      - 2ee65053-daf5-4986-a6f7-ade68e7fe9c9
+      - 8afa0cae-0c7d-400c-9fdf-4d3a1d1ff115
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222734Z:2ee65053-daf5-4986-a6f7-ade68e7fe9c9
+      - WESTCENTRALUS:20171207T214731Z:8afa0cae-0c7d-400c-9fdf-4d3a1d1ff115
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:33 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6e243932-e907-485f-b5bd-08e62b9a8df5
-      X-Ms-Correlation-Request-Id:
-      - 6e243932-e907-485f-b5bd-08e62b9a8df5
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222734Z:6e243932-e907-485f-b5bd-08e62b9a8df5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:34 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a5024a32-0bc0-4e7e-9279-38d6044a903b
-      X-Ms-Correlation-Request-Id:
-      - a5024a32-0bc0-4e7e-9279-38d6044a903b
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222735Z:a5024a32-0bc0-4e7e-9279-38d6044a903b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:34 GMT
+      - Thu, 07 Dec 2017 21:47:30 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:35 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:31 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2412,7 +2315,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2429,25 +2332,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f10d5af8-3467-4662-8b4e-31bb83b5c443
+      - 3d527a6e-bd8d-444c-9045-4cf7c9dbc396
       X-Ms-Correlation-Request-Id:
-      - f10d5af8-3467-4662-8b4e-31bb83b5c443
+      - 3d527a6e-bd8d-444c-9045-4cf7c9dbc396
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222736Z:f10d5af8-3467-4662-8b4e-31bb83b5c443
+      - WESTCENTRALUS:20171207T214732Z:3d527a6e-bd8d-444c-9045-4cf7c9dbc396
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:35 GMT
+      - Thu, 07 Dec 2017 21:47:31 GMT
       Content-Length:
-      - '550'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:36 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:32 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2461,7 +2364,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2478,25 +2381,123 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 456f486a-5407-4943-afab-2c4976891745
+      - 7f744d94-3d45-4fcf-81c1-1d73a8442474
       X-Ms-Correlation-Request-Id:
-      - 456f486a-5407-4943-afab-2c4976891745
+      - 7f744d94-3d45-4fcf-81c1-1d73a8442474
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222737Z:456f486a-5407-4943-afab-2c4976891745
+      - WESTCENTRALUS:20171207T214732Z:7f744d94-3d45-4fcf-81c1-1d73a8442474
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:37 GMT
+      - Thu, 07 Dec 2017 21:47:32 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2e63a761-74ae-4718-a44c-f73875264d75
+      X-Ms-Correlation-Request-Id:
+      - 2e63a761-74ae-4718-a44c-f73875264d75
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214733Z:2e63a761-74ae-4718-a44c-f73875264d75
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:32 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9a134b07-cc82-4a78-be0f-ecfbdf0f7bbe
+      X-Ms-Correlation-Request-Id:
+      - 9a134b07-cc82-4a78-be0f-ecfbdf0f7bbe
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214733Z:9a134b07-cc82-4a78-be0f-ecfbdf0f7bbe
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:32 GMT
       Content-Length:
       - '1104'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2","name":"jf-metrics-2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3","name":"jf-metrics-3","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1","name":"miqazure-oraclelinux1","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2","name":"miqazure-oraclelinux2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"false"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:37 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2510,7 +2511,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2527,25 +2528,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - fe216397-7b8e-45ed-9ebf-23473f386790
+      - 94f1c982-7d4e-4b97-a06b-f2cd7dbb807f
       X-Ms-Correlation-Request-Id:
-      - fe216397-7b8e-45ed-9ebf-23473f386790
+      - 94f1c982-7d4e-4b97-a06b-f2cd7dbb807f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222737Z:fe216397-7b8e-45ed-9ebf-23473f386790
+      - WESTCENTRALUS:20171207T214733Z:94f1c982-7d4e-4b97-a06b-f2cd7dbb807f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:37 GMT
+      - Thu, 07 Dec 2017 21:47:33 GMT
       Content-Length:
-      - '547'
+      - '563'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:37 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2559,7 +2560,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2576,25 +2577,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9bb46368-a6f0-4b6d-9d0c-fba7485cb179
+      - fb8429f2-0d3f-4365-b7bd-8bae5f358276
       X-Ms-Correlation-Request-Id:
-      - 9bb46368-a6f0-4b6d-9d0c-fba7485cb179
+      - fb8429f2-0d3f-4365-b7bd-8bae5f358276
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222738Z:9bb46368-a6f0-4b6d-9d0c-fba7485cb179
+      - WESTCENTRALUS:20171207T214734Z:fb8429f2-0d3f-4365-b7bd-8bae5f358276
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:38 GMT
+      - Thu, 07 Dec 2017 21:47:34 GMT
       Content-Length:
       - '3378'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","name":"miq-test-rhel1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","name":"miq-test-ubuntu1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","name":"miq-test-win12","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","name":"miq-test-winimg","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","name":"miqazure-centos1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","name":"rspec-lb-a","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","name":"rspec-lb-b","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","name":"spec0deply1vm0","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","name":"spec0deply1vm1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2","name":"miqmismatch2","type":"Microsoft.Compute/virtualMachines","location":"eastus","plan":{"name":"rhel74","product":"rhel-byol-preview","publisher":"redhat"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/dbergerprov1","name":"dbergerprov1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","name":"miqazure-linux-managed","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1","name":"miqmismatch1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:38 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2608,7 +2609,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2625,25 +2626,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1dedaba4-cfcd-4dda-be3c-21c602017614
+      - 7211ce8b-7ba8-40de-a47c-9869e32984f7
       X-Ms-Correlation-Request-Id:
-      - 1dedaba4-cfcd-4dda-be3c-21c602017614
+      - 7211ce8b-7ba8-40de-a47c-9869e32984f7
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222739Z:1dedaba4-cfcd-4dda-be3c-21c602017614
+      - WESTCENTRALUS:20171207T214734Z:7211ce8b-7ba8-40de-a47c-9869e32984f7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:39 GMT
+      - Thu, 07 Dec 2017 21:47:34 GMT
       Content-Length:
-      - '548'
+      - '564'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:39 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2657,7 +2658,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2674,25 +2675,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9c8d24f1-6577-4674-9a70-2c25bf7a15c2
+      - f4aadc54-2551-416f-ac6f-ab3b1f55bb6d
       X-Ms-Correlation-Request-Id:
-      - 9c8d24f1-6577-4674-9a70-2c25bf7a15c2
+      - f4aadc54-2551-416f-ac6f-ab3b1f55bb6d
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222740Z:9c8d24f1-6577-4674-9a70-2c25bf7a15c2
+      - WESTCENTRALUS:20171207T214735Z:f4aadc54-2551-416f-ac6f-ab3b1f55bb6d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:40 GMT
+      - Thu, 07 Dec 2017 21:47:34 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:40 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2706,7 +2707,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2723,25 +2724,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ee21f923-9461-40cd-b4a8-5aa6ee008e11
+      - f9d0ab5b-4be3-4aa7-902b-67ff4933cf05
       X-Ms-Correlation-Request-Id:
-      - ee21f923-9461-40cd-b4a8-5aa6ee008e11
+      - f9d0ab5b-4be3-4aa7-902b-67ff4933cf05
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222741Z:ee21f923-9461-40cd-b4a8-5aa6ee008e11
+      - WESTCENTRALUS:20171207T214735Z:f9d0ab5b-4be3-4aa7-902b-67ff4933cf05
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:41 GMT
+      - Thu, 07 Dec 2017 21:47:35 GMT
       Content-Length:
-      - '547'
+      - '563'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:41 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2755,7 +2756,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2772,25 +2773,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 004f9c9b-806d-415e-b980-5792bf964e79
+      - 0e79be3d-0e85-4c98-8ce3-f8de5e673e89
       X-Ms-Correlation-Request-Id:
-      - 004f9c9b-806d-415e-b980-5792bf964e79
+      - 0e79be3d-0e85-4c98-8ce3-f8de5e673e89
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222742Z:004f9c9b-806d-415e-b980-5792bf964e79
+      - WESTCENTRALUS:20171207T214736Z:0e79be3d-0e85-4c98-8ce3-f8de5e673e89
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:41 GMT
+      - Thu, 07 Dec 2017 21:47:35 GMT
       Content-Length:
       - '280'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1","name":"miqazure-coreos1","type":"Microsoft.Compute/virtualMachines","location":"westus","tags":{"Shutdown":"true"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:42 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2804,7 +2805,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2821,25 +2822,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e7188435-6cde-40b2-877c-9f9e42f6adda
+      - b42272a6-21f8-4c4c-aa3b-1311a379bd2a
       X-Ms-Correlation-Request-Id:
-      - e7188435-6cde-40b2-877c-9f9e42f6adda
+      - b42272a6-21f8-4c4c-aa3b-1311a379bd2a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222743Z:e7188435-6cde-40b2-877c-9f9e42f6adda
+      - WESTCENTRALUS:20171207T214736Z:b42272a6-21f8-4c4c-aa3b-1311a379bd2a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:42 GMT
+      - Thu, 07 Dec 2017 21:47:36 GMT
       Content-Length:
-      - '555'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:43 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2853,7 +2854,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -2870,123 +2871,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - db0ad653-7de5-4612-96e1-c5c74c2a5f8c
+      - a1af0580-2925-4e71-8fbf-f6396fcbcae2
       X-Ms-Correlation-Request-Id:
-      - db0ad653-7de5-4612-96e1-c5c74c2a5f8c
+      - a1af0580-2925-4e71-8fbf-f6396fcbcae2
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222743Z:db0ad653-7de5-4612-96e1-c5c74c2a5f8c
+      - WESTCENTRALUS:20171207T214736Z:a1af0580-2925-4e71-8fbf-f6396fcbcae2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:43 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - cdbd2367-6842-4d53-bebd-6a9e5040f204
-      X-Ms-Correlation-Request-Id:
-      - cdbd2367-6842-4d53-bebd-6a9e5040f204
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222744Z:cdbd2367-6842-4d53-bebd-6a9e5040f204
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:44 GMT
-      Content-Length:
-      - '555'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - c05ddcd5-eb92-4c6a-b66c-6f98691add45
-      X-Ms-Correlation-Request-Id:
-      - c05ddcd5-eb92-4c6a-b66c-6f98691add45
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222745Z:c05ddcd5-eb92-4c6a-b66c-6f98691add45
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:44 GMT
+      - Thu, 07 Dec 2017 21:47:36 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:45 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3000,7 +2903,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3017,25 +2920,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c8107655-c593-45b6-90a4-291b32578106
+      - e2a83392-f354-461f-aa83-563142e63cd8
       X-Ms-Correlation-Request-Id:
-      - c8107655-c593-45b6-90a4-291b32578106
+      - e2a83392-f354-461f-aa83-563142e63cd8
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222746Z:c8107655-c593-45b6-90a4-291b32578106
+      - WESTCENTRALUS:20171207T214737Z:e2a83392-f354-461f-aa83-563142e63cd8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:45 GMT
+      - Thu, 07 Dec 2017 21:47:36 GMT
       Content-Length:
-      - '552'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:46 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3049,7 +2952,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3066,123 +2969,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2056dcd5-bb0f-4ebb-b459-abe34030ebea
+      - a6ff353d-c1ce-4bbb-9842-73e51ee15c8b
       X-Ms-Correlation-Request-Id:
-      - 2056dcd5-bb0f-4ebb-b459-abe34030ebea
+      - a6ff353d-c1ce-4bbb-9842-73e51ee15c8b
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222746Z:2056dcd5-bb0f-4ebb-b459-abe34030ebea
+      - WESTCENTRALUS:20171207T214737Z:a6ff353d-c1ce-4bbb-9842-73e51ee15c8b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:46 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ee0fc61e-8b2b-4d83-80b5-18ed81bcea1d
-      X-Ms-Correlation-Request-Id:
-      - ee0fc61e-8b2b-4d83-80b5-18ed81bcea1d
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222747Z:ee0fc61e-8b2b-4d83-80b5-18ed81bcea1d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:47 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0dc7824c-0b81-4284-b371-6cb020a66393
-      X-Ms-Correlation-Request-Id:
-      - 0dc7824c-0b81-4284-b371-6cb020a66393
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222747Z:0dc7824c-0b81-4284-b371-6cb020a66393
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:47 GMT
+      - Thu, 07 Dec 2017 21:47:37 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:48 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3196,7 +3001,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3213,25 +3018,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a36cb93f-c195-498a-8411-349f3c1f31db
+      - b9efc8f8-6b00-4c67-b201-930efff905a9
       X-Ms-Correlation-Request-Id:
-      - a36cb93f-c195-498a-8411-349f3c1f31db
+      - b9efc8f8-6b00-4c67-b201-930efff905a9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222748Z:a36cb93f-c195-498a-8411-349f3c1f31db
+      - WESTCENTRALUS:20171207T214737Z:b9efc8f8-6b00-4c67-b201-930efff905a9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:48 GMT
+      - Thu, 07 Dec 2017 21:47:37 GMT
       Content-Length:
-      - '550'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:48 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3245,7 +3050,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3262,123 +3067,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c197a8d7-0751-4c99-95d8-60cb5ddfb7a6
+      - 6bc0d808-7553-4432-ac89-b677bb759b72
       X-Ms-Correlation-Request-Id:
-      - c197a8d7-0751-4c99-95d8-60cb5ddfb7a6
+      - 6bc0d808-7553-4432-ac89-b677bb759b72
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222749Z:c197a8d7-0751-4c99-95d8-60cb5ddfb7a6
+      - WESTCENTRALUS:20171207T214738Z:6bc0d808-7553-4432-ac89-b677bb759b72
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:48 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a57edc77-8ff1-4dd3-a1c7-571ab2edc9dd
-      X-Ms-Correlation-Request-Id:
-      - a57edc77-8ff1-4dd3-a1c7-571ab2edc9dd
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222749Z:a57edc77-8ff1-4dd3-a1c7-571ab2edc9dd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:49 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 11841878-e264-485c-94ea-af40b3f698bb
-      X-Ms-Correlation-Request-Id:
-      - 11841878-e264-485c-94ea-af40b3f698bb
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222750Z:11841878-e264-485c-94ea-af40b3f698bb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:49 GMT
+      - Thu, 07 Dec 2017 21:47:37 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:50 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:38 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3392,7 +3099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3409,25 +3116,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 809c98bf-e638-463e-b662-b26992aac36a
+      - 71cfef97-f96e-4fc8-a45e-7e66168c4119
       X-Ms-Correlation-Request-Id:
-      - 809c98bf-e638-463e-b662-b26992aac36a
+      - 71cfef97-f96e-4fc8-a45e-7e66168c4119
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222750Z:809c98bf-e638-463e-b662-b26992aac36a
+      - WESTCENTRALUS:20171207T214738Z:71cfef97-f96e-4fc8-a45e-7e66168c4119
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:50 GMT
+      - Thu, 07 Dec 2017 21:47:38 GMT
       Content-Length:
-      - '552'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:51 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:38 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3441,7 +3148,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3458,123 +3165,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 920f3b24-1f83-4035-838e-afd8fb798091
+      - 9fdbb692-37cb-4ebf-bf2b-42efbe464de5
       X-Ms-Correlation-Request-Id:
-      - 920f3b24-1f83-4035-838e-afd8fb798091
+      - 9fdbb692-37cb-4ebf-bf2b-42efbe464de5
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222751Z:920f3b24-1f83-4035-838e-afd8fb798091
+      - WESTCENTRALUS:20171207T214739Z:9fdbb692-37cb-4ebf-bf2b-42efbe464de5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:51 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b9d21203-eae8-41f4-b866-1088511c71f9
-      X-Ms-Correlation-Request-Id:
-      - b9d21203-eae8-41f4-b866-1088511c71f9
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222752Z:b9d21203-eae8-41f4-b866-1088511c71f9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:51 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0e08f35b-fbba-4bdf-bc96-117837c5fb23
-      X-Ms-Correlation-Request-Id:
-      - 0e08f35b-fbba-4bdf-bc96-117837c5fb23
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222753Z:0e08f35b-fbba-4bdf-bc96-117837c5fb23
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:52 GMT
+      - Thu, 07 Dec 2017 21:47:38 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:53 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3588,7 +3197,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3605,25 +3214,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8a08eb36-2476-486c-88ad-bf0f6eac5355
+      - 6da9310b-41d7-4dcf-8a7d-851b7fb9b59b
       X-Ms-Correlation-Request-Id:
-      - 8a08eb36-2476-486c-88ad-bf0f6eac5355
+      - 6da9310b-41d7-4dcf-8a7d-851b7fb9b59b
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222753Z:8a08eb36-2476-486c-88ad-bf0f6eac5355
+      - WESTCENTRALUS:20171207T214740Z:6da9310b-41d7-4dcf-8a7d-851b7fb9b59b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:53 GMT
+      - Thu, 07 Dec 2017 21:47:39 GMT
       Content-Length:
-      - '559'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:54 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3637,7 +3246,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3654,123 +3263,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bf4b338b-8acc-4c2d-b038-0059fe665a7c
+      - 400cf6f7-f63e-445f-8d8c-040257dfb7b5
       X-Ms-Correlation-Request-Id:
-      - bf4b338b-8acc-4c2d-b038-0059fe665a7c
+      - 400cf6f7-f63e-445f-8d8c-040257dfb7b5
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222754Z:bf4b338b-8acc-4c2d-b038-0059fe665a7c
+      - WESTCENTRALUS:20171207T214740Z:400cf6f7-f63e-445f-8d8c-040257dfb7b5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:53 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e5480fc0-07fd-4dc4-b00d-31b4e92bb2dd
-      X-Ms-Correlation-Request-Id:
-      - e5480fc0-07fd-4dc4-b00d-31b4e92bb2dd
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222755Z:e5480fc0-07fd-4dc4-b00d-31b4e92bb2dd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:54 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 698f0bef-51c1-4c4b-95f9-221e7a03231f
-      X-Ms-Correlation-Request-Id:
-      - 698f0bef-51c1-4c4b-95f9-221e7a03231f
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222755Z:698f0bef-51c1-4c4b-95f9-221e7a03231f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:55 GMT
+      - Thu, 07 Dec 2017 21:47:39 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:55 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3784,7 +3295,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3801,25 +3312,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e2c48a1c-8b29-4aed-9aa2-6b5c92058973
+      - cf4f34fe-0a35-4275-bbb7-2a38b2ee4035
       X-Ms-Correlation-Request-Id:
-      - e2c48a1c-8b29-4aed-9aa2-6b5c92058973
+      - cf4f34fe-0a35-4275-bbb7-2a38b2ee4035
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222756Z:e2c48a1c-8b29-4aed-9aa2-6b5c92058973
+      - WESTCENTRALUS:20171207T214740Z:cf4f34fe-0a35-4275-bbb7-2a38b2ee4035
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:55 GMT
+      - Thu, 07 Dec 2017 21:47:40 GMT
       Content-Length:
-      - '553'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:56 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3833,7 +3344,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3850,123 +3361,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - be7b58e1-2b7f-49ca-8ed8-9d56f85db049
+      - b84e1ceb-cccb-4ae1-b24f-c7d5c567534c
       X-Ms-Correlation-Request-Id:
-      - be7b58e1-2b7f-49ca-8ed8-9d56f85db049
+      - b84e1ceb-cccb-4ae1-b24f-c7d5c567534c
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222756Z:be7b58e1-2b7f-49ca-8ed8-9d56f85db049
+      - WESTCENTRALUS:20171207T214741Z:b84e1ceb-cccb-4ae1-b24f-c7d5c567534c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:56 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 9f707d65-9779-46bb-a12d-993c0095ee6e
-      X-Ms-Correlation-Request-Id:
-      - 9f707d65-9779-46bb-a12d-993c0095ee6e
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222757Z:9f707d65-9779-46bb-a12d-993c0095ee6e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:57 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 60ba6a32-3c9c-4360-a98c-5c088c58c05b
-      X-Ms-Correlation-Request-Id:
-      - 60ba6a32-3c9c-4360-a98c-5c088c58c05b
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222759Z:60ba6a32-3c9c-4360-a98c-5c088c58c05b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:58 GMT
+      - Thu, 07 Dec 2017 21:47:40 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:59 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3980,7 +3393,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -3997,25 +3410,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 395a7860-b542-424b-91ac-972c8220dab6
+      - 90418511-3628-4229-b51b-b1f18f156df4
       X-Ms-Correlation-Request-Id:
-      - 395a7860-b542-424b-91ac-972c8220dab6
+      - 90418511-3628-4229-b51b-b1f18f156df4
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222759Z:395a7860-b542-424b-91ac-972c8220dab6
+      - WESTCENTRALUS:20171207T214741Z:90418511-3628-4229-b51b-b1f18f156df4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:59 GMT
+      - Thu, 07 Dec 2017 21:47:41 GMT
       Content-Length:
-      - '554'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:59 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4029,7 +3442,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -4046,123 +3459,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 480d76cf-d96c-4a05-a9db-b4dae74b575c
+      - 838b79d9-a8ee-4884-a772-4554b2b525f9
       X-Ms-Correlation-Request-Id:
-      - 480d76cf-d96c-4a05-a9db-b4dae74b575c
+      - 838b79d9-a8ee-4884-a772-4554b2b525f9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222800Z:480d76cf-d96c-4a05-a9db-b4dae74b575c
+      - WESTCENTRALUS:20171207T214742Z:838b79d9-a8ee-4884-a772-4554b2b525f9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:59 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5bde45f6-4e2b-4556-ac9a-866efe4c4fe5
-      X-Ms-Correlation-Request-Id:
-      - 5bde45f6-4e2b-4556-ac9a-866efe4c4fe5
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222801Z:5bde45f6-4e2b-4556-ac9a-866efe4c4fe5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:00 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1440bdd2-48b0-446a-a0bd-4509dd4aabb9
-      X-Ms-Correlation-Request-Id:
-      - 1440bdd2-48b0-446a-a0bd-4509dd4aabb9
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222802Z:1440bdd2-48b0-446a-a0bd-4509dd4aabb9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:01 GMT
+      - Thu, 07 Dec 2017 21:47:41 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:02 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4176,7 +3491,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -4193,25 +3508,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0e3cd799-4a72-46b8-aae8-26d9b0ff2ce8
+      - 4e1fefbc-4240-4e91-b025-34316d6d2573
       X-Ms-Correlation-Request-Id:
-      - 0e3cd799-4a72-46b8-aae8-26d9b0ff2ce8
+      - 4e1fefbc-4240-4e91-b025-34316d6d2573
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222802Z:0e3cd799-4a72-46b8-aae8-26d9b0ff2ce8
+      - WESTCENTRALUS:20171207T214742Z:4e1fefbc-4240-4e91-b025-34316d6d2573
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:02 GMT
+      - Thu, 07 Dec 2017 21:47:42 GMT
       Content-Length:
-      - '548'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:02 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4225,7 +3540,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -4242,123 +3557,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 96cd86f1-1827-4918-93e8-e18afafbc8a7
+      - ac4e4b45-da6d-48b2-bd66-1a49faaf1860
       X-Ms-Correlation-Request-Id:
-      - 96cd86f1-1827-4918-93e8-e18afafbc8a7
+      - ac4e4b45-da6d-48b2-bd66-1a49faaf1860
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222803Z:96cd86f1-1827-4918-93e8-e18afafbc8a7
+      - WESTCENTRALUS:20171207T214743Z:ac4e4b45-da6d-48b2-bd66-1a49faaf1860
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:02 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b66d4563-aefb-456e-8138-91d4603e9bbf
-      X-Ms-Correlation-Request-Id:
-      - b66d4563-aefb-456e-8138-91d4603e9bbf
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222804Z:b66d4563-aefb-456e-8138-91d4603e9bbf
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:03 GMT
-      Content-Length:
-      - '547'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:04 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - c74353bf-7ad1-497b-b929-7bc1c7d191fa
-      X-Ms-Correlation-Request-Id:
-      - c74353bf-7ad1-497b-b929-7bc1c7d191fa
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222804Z:c74353bf-7ad1-497b-b929-7bc1c7d191fa
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:04 GMT
+      - Thu, 07 Dec 2017 21:47:42 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:04 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:43 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4372,7 +3589,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -4389,25 +3606,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c9072bfa-7376-48b4-b2ee-b1f701f4ce67
+      - e934b7ae-ad3c-45ea-8baa-bbc9737147de
       X-Ms-Correlation-Request-Id:
-      - c9072bfa-7376-48b4-b2ee-b1f701f4ce67
+      - e934b7ae-ad3c-45ea-8baa-bbc9737147de
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222805Z:c9072bfa-7376-48b4-b2ee-b1f701f4ce67
+      - WESTCENTRALUS:20171207T214743Z:e934b7ae-ad3c-45ea-8baa-bbc9737147de
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:05 GMT
+      - Thu, 07 Dec 2017 21:47:43 GMT
       Content-Length:
-      - '554'
+      - '575'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:05 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:43 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4421,7 +3638,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -4438,123 +3655,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ce1e9e47-3c6e-4d03-8e0a-5bba58702611
+      - 0ef43dc8-a145-44b5-8f1f-66e55d20d030
       X-Ms-Correlation-Request-Id:
-      - ce1e9e47-3c6e-4d03-8e0a-5bba58702611
+      - 0ef43dc8-a145-44b5-8f1f-66e55d20d030
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222806Z:ce1e9e47-3c6e-4d03-8e0a-5bba58702611
+      - WESTCENTRALUS:20171207T214744Z:0ef43dc8-a145-44b5-8f1f-66e55d20d030
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:05 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - c710e792-474e-4634-aeda-bc375237ff99
-      X-Ms-Correlation-Request-Id:
-      - c710e792-474e-4634-aeda-bc375237ff99
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222806Z:c710e792-474e-4634-aeda-bc375237ff99
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:05 GMT
-      Content-Length:
-      - '548'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 39d6d1b9-d47f-4bf6-94c6-6ce4c23071b0
-      X-Ms-Correlation-Request-Id:
-      - 39d6d1b9-d47f-4bf6-94c6-6ce4c23071b0
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222807Z:39d6d1b9-d47f-4bf6-94c6-6ce4c23071b0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:07 GMT
+      - Thu, 07 Dec 2017 21:47:43 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:07 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4568,7 +3687,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -4585,25 +3704,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1a449d1d-d7ef-4ce4-a2ea-8cc301f31e2c
+      - 5e381d78-9394-4332-9a3f-8fec4dbbf35a
       X-Ms-Correlation-Request-Id:
-      - 1a449d1d-d7ef-4ce4-a2ea-8cc301f31e2c
+      - 5e381d78-9394-4332-9a3f-8fec4dbbf35a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222807Z:1a449d1d-d7ef-4ce4-a2ea-8cc301f31e2c
+      - WESTCENTRALUS:20171207T214744Z:5e381d78-9394-4332-9a3f-8fec4dbbf35a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:07 GMT
+      - Thu, 07 Dec 2017 21:47:44 GMT
       Content-Length:
-      - '553'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:08 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4617,7 +3736,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
   response:
     status:
       code: 200
@@ -4634,118 +3753,1000 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6538e15c-eb4b-433e-baf0-f206bdab75fd
+      - f13655b1-2ba4-4419-be9b-55a985b22f6f
       X-Ms-Correlation-Request-Id:
-      - 6538e15c-eb4b-433e-baf0-f206bdab75fd
+      - f13655b1-2ba4-4419-be9b-55a985b22f6f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222808Z:6538e15c-eb4b-433e-baf0-f206bdab75fd
+      - WESTCENTRALUS:20171207T214744Z:f13655b1-2ba4-4419-be9b-55a985b22f6f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:08 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 397c4ff8-82e8-4030-9850-18b6deac6538
-      X-Ms-Correlation-Request-Id:
-      - 397c4ff8-82e8-4030-9850-18b6deac6538
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222809Z:397c4ff8-82e8-4030-9850-18b6deac6538
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:08 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5NTAsIm5iZiI6MTUxMjE2Njk1MCwiZXhwIjoxNTEyMTcwODUwLCJhaW8iOiJZMk5nWVBqRCtmcmtIdWJsMzlaYStHemN0dnY5ZHdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRmJVUmNLM05FRTZyLWxmTlJUVXVBQSIsInZlciI6IjEuMCJ9.In3yKdfWCfwiyVfX4xhMSm1Kzy-Ii1qFDf8XBb6axWATAbz5dr-3Zm2QV5I8szHgh6fUxr-cWt9eIYMRKk8nCLDuHlO5ZsjkP7vTZ_ERGY_qoMzDwuCQh_ik8Lm07nkkl6l1clkBAxrbREuy7hMtrt3xdoqaKgyghAh7htPG7DifF1htPKrcXTI8ibnHcKiH1DRnVbWjF3h3WGNJc5cprMeXwNSosUp9KGr0Y8C9fbIK_F7kQE-gMi-N9qBpvP_AALYFmQkiFoQjV7nXRljDY5ctx7-_Gmp60qgyuGmMLAbwIJ9_WQYCg5DCrLgiZC1mnDvgu2vf2Txeti_PFTiOdw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e717c47c-2161-4e5f-9c7c-cc977d7b3a3f
-      X-Ms-Correlation-Request-Id:
-      - e717c47c-2161-4e5f-9c7c-cc977d7b3a3f
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222809Z:e717c47c-2161-4e5f-9c7c-cc977d7b3a3f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:09 GMT
+      - Thu, 07 Dec 2017 21:47:44 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:09 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a9045744-cb26-4d58-a452-dd0ec6fb564b
+      X-Ms-Correlation-Request-Id:
+      - a9045744-cb26-4d58-a452-dd0ec6fb564b
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214745Z:a9045744-cb26-4d58-a452-dd0ec6fb564b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:45 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9ec5f243-ecbb-4db6-8c28-562d06ffcdc1
+      X-Ms-Correlation-Request-Id:
+      - 9ec5f243-ecbb-4db6-8c28-562d06ffcdc1
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214745Z:9ec5f243-ecbb-4db6-8c28-562d06ffcdc1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:45 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7d0fdd28-1515-4987-a6f3-4ec63bea295c
+      X-Ms-Correlation-Request-Id:
+      - 7d0fdd28-1515-4987-a6f3-4ec63bea295c
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214746Z:7d0fdd28-1515-4987-a6f3-4ec63bea295c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:45 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c7c05b2a-c523-40be-a177-def202d71f89
+      X-Ms-Correlation-Request-Id:
+      - c7c05b2a-c523-40be-a177-def202d71f89
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214746Z:c7c05b2a-c523-40be-a177-def202d71f89
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:45 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b2fb9478-ebe2-4729-8064-108d6c0ad61d
+      X-Ms-Correlation-Request-Id:
+      - b2fb9478-ebe2-4729-8064-108d6c0ad61d
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214746Z:b2fb9478-ebe2-4729-8064-108d6c0ad61d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:46 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 612c3a64-e5ab-4657-b452-7dd25b876227
+      X-Ms-Correlation-Request-Id:
+      - 612c3a64-e5ab-4657-b452-7dd25b876227
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214747Z:612c3a64-e5ab-4657-b452-7dd25b876227
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:46 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - bcf3886a-2d01-4b9d-ac5a-6cb2b35c46d0
+      X-Ms-Correlation-Request-Id:
+      - bcf3886a-2d01-4b9d-ac5a-6cb2b35c46d0
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214747Z:bcf3886a-2d01-4b9d-ac5a-6cb2b35c46d0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:47 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - '080dc1f8-e601-4e55-b612-0fb6b5af73e1'
+      X-Ms-Correlation-Request-Id:
+      - '080dc1f8-e601-4e55-b612-0fb6b5af73e1'
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214748Z:080dc1f8-e601-4e55-b612-0fb6b5af73e1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:47 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 61a67569-5fb8-4179-92c3-c10ffeac7e80
+      X-Ms-Correlation-Request-Id:
+      - 61a67569-5fb8-4179-92c3-c10ffeac7e80
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214748Z:61a67569-5fb8-4179-92c3-c10ffeac7e80
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:48 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d174f6f4-185e-48b3-a680-65a04d358085
+      X-Ms-Correlation-Request-Id:
+      - d174f6f4-185e-48b3-a680-65a04d358085
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214749Z:d174f6f4-185e-48b3-a680-65a04d358085
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:48 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 34070ea1-ba39-4522-b3c7-c3bbb0fc1d8b
+      X-Ms-Correlation-Request-Id:
+      - 34070ea1-ba39-4522-b3c7-c3bbb0fc1d8b
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214749Z:34070ea1-ba39-4522-b3c7-c3bbb0fc1d8b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:48 GMT
+      Content-Length:
+      - '563'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9b5a7fa8-e38e-4dea-a548-99e3a0044ba5
+      X-Ms-Correlation-Request-Id:
+      - 9b5a7fa8-e38e-4dea-a548-99e3a0044ba5
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214749Z:9b5a7fa8-e38e-4dea-a548-99e3a0044ba5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:48 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2e05217b-5382-4c6a-bd86-4efb2045e585
+      X-Ms-Correlation-Request-Id:
+      - 2e05217b-5382-4c6a-bd86-4efb2045e585
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214750Z:2e05217b-5382-4c6a-bd86-4efb2045e585
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:49 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7d1117af-7f4d-4c21-91d7-eef37e904844
+      X-Ms-Correlation-Request-Id:
+      - 7d1117af-7f4d-4c21-91d7-eef37e904844
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214750Z:7d1117af-7f4d-4c21-91d7-eef37e904844
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:49 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 37048d72-14a8-40b4-a38f-e0808c947c6a
+      X-Ms-Correlation-Request-Id:
+      - 37048d72-14a8-40b4-a38f-e0808c947c6a
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214750Z:37048d72-14a8-40b4-a38f-e0808c947c6a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:49 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b14190e0-6575-4cd1-a784-57cc402f27dc
+      X-Ms-Correlation-Request-Id:
+      - b14190e0-6575-4cd1-a784-57cc402f27dc
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214751Z:b14190e0-6575-4cd1-a784-57cc402f27dc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:50 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - dd9f2e09-5324-4a89-8fba-d806be929062
+      X-Ms-Correlation-Request-Id:
+      - dd9f2e09-5324-4a89-8fba-d806be929062
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214751Z:dd9f2e09-5324-4a89-8fba-d806be929062
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:51 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9f6ebee6-d916-4dce-8bf1-f5f90ff2c217
+      X-Ms-Correlation-Request-Id:
+      - 9f6ebee6-d916-4dce-8bf1-f5f90ff2c217
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214752Z:9f6ebee6-d916-4dce-8bf1-f5f90ff2c217
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:51 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - adb0269c-13d2-4003-8be4-aea3c4652983
+      X-Ms-Correlation-Request-Id:
+      - adb0269c-13d2-4003-8be4-aea3c4652983
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214752Z:adb0269c-13d2-4003-8be4-aea3c4652983
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:52 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5NDksIm5iZiI6MTUxMjY4Mjk0OSwiZXhwIjoxNTEyNjg2ODQ5LCJhaW8iOiJZMk5nWUZEMG5yQjN6K1dBamUvMkt2dDRyejh5RVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMl9rcUdXSFFPRVd2RWtXbnprSU1BQSIsInZlciI6IjEuMCJ9.lhQoFVkBjRr_6DN8cbpIQ2ldeDC_On7fLVQ_7_jO2m8yjZEGgBL7w_5No_JWeRCPsh-oGniBCXWcszH9P5S6iLp5mlzQ5JA6jPIzhbYASh_CrfwGvewZdmFvRMO7WqYu4JIDrg-WYLb4BFGf_QsTfje9nvn0hXxLnR6FDspS7aJrqta05is7Y9o2ZnS46sUQGzCHXarRFpdIIguBt_1UMI_PGyQkbMoP3S86EC7CQEFSkouBEndVmqb6V7oWOX1O2uMDOflBnWOb1ops1OfK4ndEP6MafLZDCYXJwv1S9HuR_HVsrCMFQn5_mm97NJ0NnLFKa51TNnSMllj-2Bj-aQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e498617d-f1a8-4211-b09e-0ff75d83396e
+      X-Ms-Correlation-Request-Id:
+      - e498617d-f1a8-4211-b09e-0ff75d83396e
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214752Z:e498617d-f1a8-4211-b09e-0ff75d83396e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:52 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:52 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_some_existing_records.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_some_existing_records.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 68cb014f-6a7a-4e4a-bcb4-64977b342b00
+      - 78a00fcc-9d25-4553-8b4b-0c1e79340c00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzm9Em8smzJG1GQU8TvLEjFdZzIuPLaLFDKemtWwkalUveIu-2wT7zWUQWIkCUO_3u5MUTcLqFIKBmIO_GSnNE05oy8brJCbtbQG469aWjA0ARDJAdCDpdmS9YSagEgFwyDWuDdJL0TiCtWz9YsYQpZZWKBL2iN3La9tHwrMcMkSggAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzJ3rM0UB4y-MJQAbjyyS1SYm5t6jgGnheV6BpH5nSqdqVADdJRAdULsx6qzx_p0o7FQfpGXGiTwFpjGEvyIzrrOfkAEmK1WAFJ_lhDEmSqj4wvpj6CA8J46VdMC2LGyDd-PwnSvn_OUfNnnnxTr2dJyaFjdro9ricrYV9JPVir5MgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 01 Dec 2017 22:26:51 GMT
+      - Thu, 07 Dec 2017 21:47:02 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1512170812","not_before":"1512166912","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1512686824","not_before":"1512682924","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:26:53 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:03 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -93,21 +93,21 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 589d0a80-45f0-4237-8e0c-6ef0389613fe
+      - fdd01df1-f453-49e1-a7ec-800015cb78ce
       X-Ms-Correlation-Request-Id:
-      - 589d0a80-45f0-4237-8e0c-6ef0389613fe
+      - fdd01df1-f453-49e1-a7ec-800015cb78ce
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222653Z:589d0a80-45f0-4237-8e0c-6ef0389613fe
+      - WESTCENTRALUS:20171207T214704Z:fdd01df1-f453-49e1-a7ec-800015cb78ce
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:26:52 GMT
+      - Thu, 07 Dec 2017 21:47:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:26:53 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:04 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -124,7 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -141,19 +141,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14925'
+      - '14999'
       X-Ms-Request-Id:
-      - 5868b2d6-fa6c-4427-b5e7-433b99a10b0e
+      - 447a74e1-bac6-4e30-8eda-6fb0f0385fce
       X-Ms-Correlation-Request-Id:
-      - 5868b2d6-fa6c-4427-b5e7-433b99a10b0e
+      - 447a74e1-bac6-4e30-8eda-6fb0f0385fce
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222654Z:5868b2d6-fa6c-4427-b5e7-433b99a10b0e
+      - WESTCENTRALUS:20171207T214705Z:447a74e1-bac6-4e30-8eda-6fb0f0385fce
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:26:53 GMT
+      - Thu, 07 Dec 2017 21:47:04 GMT
       Content-Length:
-      - '278554'
+      - '279208'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -260,7 +260,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -491,7 +491,7 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
-        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
         US","UK West","West India","Australia East","Brazil South","Canada East","East
@@ -614,92 +614,92 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","North
         Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
         South","Japan East","Japan West","North Europe","West Europe","Central India","South
@@ -816,7 +816,7 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
@@ -1459,7 +1459,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1606,7 +1606,8 @@ http_interactions:
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
@@ -1873,23 +1874,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1938,8 +1939,8 @@ http_interactions:
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
         Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
-        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"operations","locations":["Central
-        US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
@@ -2017,8 +2018,8 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -2030,18 +2031,18 @@ http_interactions:
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
@@ -2122,7 +2123,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:26:54 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:05 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/locations?api-version=2015-01-01
@@ -2139,7 +2140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2156,17 +2157,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14925'
+      - '14981'
       X-Ms-Request-Id:
-      - 9f401280-0bd8-4af9-b61c-59c4f3c561a3
+      - ee322c51-cdf1-4dfe-8439-b1ee0fb58726
       X-Ms-Correlation-Request-Id:
-      - 9f401280-0bd8-4af9-b61c-59c4f3c561a3
+      - ee322c51-cdf1-4dfe-8439-b1ee0fb58726
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222655Z:9f401280-0bd8-4af9-b61c-59c4f3c561a3
+      - WESTCENTRALUS:20171207T214705Z:ee322c51-cdf1-4dfe-8439-b1ee0fb58726
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:26:54 GMT
+      - Thu, 07 Dec 2017 21:47:05 GMT
       Content-Length:
       - '4523'
     body:
@@ -2199,10 +2200,10 @@ http_interactions:
         Central","longitude":"126.9780","latitude":"37.5665"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/locations/koreasouth","name":"koreasouth","displayName":"Korea
         South","longitude":"129.0756","latitude":"35.1796"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:26:55 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2216,7 +2217,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2233,25 +2234,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - fd9faaae-a6a8-4183-8872-9041e98243fc
+      - 5447d492-c7ed-44d0-b376-eacb1b0e7a7e
       X-Ms-Correlation-Request-Id:
-      - fd9faaae-a6a8-4183-8872-9041e98243fc
+      - 5447d492-c7ed-44d0-b376-eacb1b0e7a7e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222656Z:fd9faaae-a6a8-4183-8872-9041e98243fc
+      - WESTCENTRALUS:20171207T214706Z:5447d492-c7ed-44d0-b376-eacb1b0e7a7e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:26:56 GMT
+      - Thu, 07 Dec 2017 21:47:05 GMT
       Content-Length:
-      - '549'
+      - '565'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:26:56 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:06 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2265,7 +2266,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2282,123 +2283,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7bbc4fab-a54a-4576-af7e-dcd3272651ea
+      - b8021983-3364-4bc5-9f8b-9d7d653217ed
       X-Ms-Correlation-Request-Id:
-      - 7bbc4fab-a54a-4576-af7e-dcd3272651ea
+      - b8021983-3364-4bc5-9f8b-9d7d653217ed
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222657Z:7bbc4fab-a54a-4576-af7e-dcd3272651ea
+      - WESTCENTRALUS:20171207T214707Z:b8021983-3364-4bc5-9f8b-9d7d653217ed
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:26:56 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:26:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 41735b92-ea2b-44a0-a638-621e83a202b3
-      X-Ms-Correlation-Request-Id:
-      - 41735b92-ea2b-44a0-a638-621e83a202b3
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222657Z:41735b92-ea2b-44a0-a638-621e83a202b3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:26:57 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:26:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 53a8143d-c4a1-4b58-8d2d-faec6ddf53f8
-      X-Ms-Correlation-Request-Id:
-      - 53a8143d-c4a1-4b58-8d2d-faec6ddf53f8
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222658Z:53a8143d-c4a1-4b58-8d2d-faec6ddf53f8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:26:58 GMT
+      - Thu, 07 Dec 2017 21:47:06 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:26:58 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2412,7 +2315,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2429,25 +2332,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 73ff9954-ab5d-4145-84cd-067d33865cba
+      - 30f0dd93-73b0-42c9-bb52-b73725d7d0a8
       X-Ms-Correlation-Request-Id:
-      - 73ff9954-ab5d-4145-84cd-067d33865cba
+      - 30f0dd93-73b0-42c9-bb52-b73725d7d0a8
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222659Z:73ff9954-ab5d-4145-84cd-067d33865cba
+      - WESTCENTRALUS:20171207T214707Z:30f0dd93-73b0-42c9-bb52-b73725d7d0a8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:26:58 GMT
+      - Thu, 07 Dec 2017 21:47:06 GMT
       Content-Length:
-      - '550'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:26:59 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2461,7 +2364,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2478,25 +2381,123 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2cef78bc-afe9-4889-901f-07b68f149671
+      - 5585dcd7-acbc-4d52-b9aa-6500a415da84
       X-Ms-Correlation-Request-Id:
-      - 2cef78bc-afe9-4889-901f-07b68f149671
+      - 5585dcd7-acbc-4d52-b9aa-6500a415da84
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222659Z:2cef78bc-afe9-4889-901f-07b68f149671
+      - WESTCENTRALUS:20171207T214708Z:5585dcd7-acbc-4d52-b9aa-6500a415da84
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:26:59 GMT
+      - Thu, 07 Dec 2017 21:47:07 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - cdb87944-e940-4575-a2ae-9e6b8741989b
+      X-Ms-Correlation-Request-Id:
+      - cdb87944-e940-4575-a2ae-9e6b8741989b
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214708Z:cdb87944-e940-4575-a2ae-9e6b8741989b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:07 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a8bd4c7a-2fe0-4b52-bfba-cc48d9f2f6f2
+      X-Ms-Correlation-Request-Id:
+      - a8bd4c7a-2fe0-4b52-bfba-cc48d9f2f6f2
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214708Z:a8bd4c7a-2fe0-4b52-bfba-cc48d9f2f6f2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:08 GMT
       Content-Length:
       - '1104'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2","name":"jf-metrics-2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3","name":"jf-metrics-3","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1","name":"miqazure-oraclelinux1","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2","name":"miqazure-oraclelinux2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"false"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:26:59 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2510,7 +2511,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2527,25 +2528,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7775f693-f9d3-438e-a2f3-15b7fa8ffc49
+      - e4e285e4-3019-4650-a471-faf001bfee7f
       X-Ms-Correlation-Request-Id:
-      - 7775f693-f9d3-438e-a2f3-15b7fa8ffc49
+      - e4e285e4-3019-4650-a471-faf001bfee7f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222700Z:7775f693-f9d3-438e-a2f3-15b7fa8ffc49
+      - WESTCENTRALUS:20171207T214709Z:e4e285e4-3019-4650-a471-faf001bfee7f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:26:59 GMT
+      - Thu, 07 Dec 2017 21:47:08 GMT
       Content-Length:
-      - '548'
+      - '564'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:00 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2559,7 +2560,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2576,25 +2577,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0ac1133a-139e-4765-aa63-2b6471233003
+      - 26b0f4c0-4f14-410a-9961-2971b0007eae
       X-Ms-Correlation-Request-Id:
-      - 0ac1133a-139e-4765-aa63-2b6471233003
+      - 26b0f4c0-4f14-410a-9961-2971b0007eae
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222700Z:0ac1133a-139e-4765-aa63-2b6471233003
+      - WESTCENTRALUS:20171207T214709Z:26b0f4c0-4f14-410a-9961-2971b0007eae
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:00 GMT
+      - Thu, 07 Dec 2017 21:47:09 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:01 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2608,7 +2609,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2625,25 +2626,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f07d45fb-afed-40cd-a059-bfdf1193b74a
+      - 41a57c51-f266-472d-b9b7-585749b2ae5d
       X-Ms-Correlation-Request-Id:
-      - f07d45fb-afed-40cd-a059-bfdf1193b74a
+      - 41a57c51-f266-472d-b9b7-585749b2ae5d
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222701Z:f07d45fb-afed-40cd-a059-bfdf1193b74a
+      - WESTCENTRALUS:20171207T214710Z:41a57c51-f266-472d-b9b7-585749b2ae5d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:00 GMT
+      - Thu, 07 Dec 2017 21:47:09 GMT
       Content-Length:
-      - '547'
+      - '563'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:01 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2657,7 +2658,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2674,25 +2675,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e7bca911-2e35-4b64-bae3-4faaa99a465c
+      - 53c3f56c-877b-45d6-a3d2-f1217e089150
       X-Ms-Correlation-Request-Id:
-      - e7bca911-2e35-4b64-bae3-4faaa99a465c
+      - 53c3f56c-877b-45d6-a3d2-f1217e089150
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222702Z:e7bca911-2e35-4b64-bae3-4faaa99a465c
+      - WESTCENTRALUS:20171207T214710Z:53c3f56c-877b-45d6-a3d2-f1217e089150
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:01 GMT
+      - Thu, 07 Dec 2017 21:47:09 GMT
       Content-Length:
       - '280'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1","name":"miqazure-coreos1","type":"Microsoft.Compute/virtualMachines","location":"westus","tags":{"Shutdown":"true"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:02 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2706,7 +2707,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2723,25 +2724,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b6d7d083-31c4-4a2b-a720-65ef6441ddc7
+      - 29b61f64-83be-43b7-8d84-3da2d0208e7c
       X-Ms-Correlation-Request-Id:
-      - b6d7d083-31c4-4a2b-a720-65ef6441ddc7
+      - 29b61f64-83be-43b7-8d84-3da2d0208e7c
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222703Z:b6d7d083-31c4-4a2b-a720-65ef6441ddc7
+      - WESTCENTRALUS:20171207T214710Z:29b61f64-83be-43b7-8d84-3da2d0208e7c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:03 GMT
+      - Thu, 07 Dec 2017 21:47:10 GMT
       Content-Length:
-      - '555'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:03 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2755,7 +2756,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2772,123 +2773,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ceffc7e1-535f-425b-97bb-4192ca358a34
+      - 292668e6-e63b-4b74-82d2-c579147ff48a
       X-Ms-Correlation-Request-Id:
-      - ceffc7e1-535f-425b-97bb-4192ca358a34
+      - 292668e6-e63b-4b74-82d2-c579147ff48a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222703Z:ceffc7e1-535f-425b-97bb-4192ca358a34
+      - WESTCENTRALUS:20171207T214711Z:292668e6-e63b-4b74-82d2-c579147ff48a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:03 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:04 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 964b63b0-9ee8-4e8e-bec9-51c0b62d1431
-      X-Ms-Correlation-Request-Id:
-      - 964b63b0-9ee8-4e8e-bec9-51c0b62d1431
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222704Z:964b63b0-9ee8-4e8e-bec9-51c0b62d1431
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:04 GMT
-      Content-Length:
-      - '555'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:04 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 91dc40d4-406c-48c1-86a3-4a37c9491650
-      X-Ms-Correlation-Request-Id:
-      - 91dc40d4-406c-48c1-86a3-4a37c9491650
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222705Z:91dc40d4-406c-48c1-86a3-4a37c9491650
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:04 GMT
+      - Thu, 07 Dec 2017 21:47:11 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:05 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2902,7 +2805,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2919,25 +2822,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a0ee969c-1c49-4a75-afa0-9b57339fed97
+      - 913b4035-86d9-4c88-b8ba-2204e2695634
       X-Ms-Correlation-Request-Id:
-      - a0ee969c-1c49-4a75-afa0-9b57339fed97
+      - 913b4035-86d9-4c88-b8ba-2204e2695634
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222705Z:a0ee969c-1c49-4a75-afa0-9b57339fed97
+      - WESTCENTRALUS:20171207T214711Z:913b4035-86d9-4c88-b8ba-2204e2695634
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:05 GMT
+      - Thu, 07 Dec 2017 21:47:11 GMT
       Content-Length:
-      - '552'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:05 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2951,7 +2854,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -2968,123 +2871,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 73d8bba8-5d30-499e-a56c-01d875e97ddb
+      - b171b680-5c6b-4d06-ac90-9588c5ad3d17
       X-Ms-Correlation-Request-Id:
-      - 73d8bba8-5d30-499e-a56c-01d875e97ddb
+      - b171b680-5c6b-4d06-ac90-9588c5ad3d17
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222706Z:73d8bba8-5d30-499e-a56c-01d875e97ddb
+      - WESTCENTRALUS:20171207T214712Z:b171b680-5c6b-4d06-ac90-9588c5ad3d17
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:06 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e5031452-a859-4503-89b4-2aa67e5d1c3c
-      X-Ms-Correlation-Request-Id:
-      - e5031452-a859-4503-89b4-2aa67e5d1c3c
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222707Z:e5031452-a859-4503-89b4-2aa67e5d1c3c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:06 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 17775130-43c8-49d7-b6b3-938f072b6066
-      X-Ms-Correlation-Request-Id:
-      - 17775130-43c8-49d7-b6b3-938f072b6066
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222707Z:17775130-43c8-49d7-b6b3-938f072b6066
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:07 GMT
+      - Thu, 07 Dec 2017 21:47:11 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:07 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3098,7 +2903,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -3115,25 +2920,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0a68fc0f-5e2d-4b63-bd8c-6faed0f27954
+      - 0ca4a8f6-4e1e-40aa-9504-cfbcdaba96cb
       X-Ms-Correlation-Request-Id:
-      - 0a68fc0f-5e2d-4b63-bd8c-6faed0f27954
+      - 0ca4a8f6-4e1e-40aa-9504-cfbcdaba96cb
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222708Z:0a68fc0f-5e2d-4b63-bd8c-6faed0f27954
+      - WESTCENTRALUS:20171207T214712Z:0ca4a8f6-4e1e-40aa-9504-cfbcdaba96cb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:07 GMT
+      - Thu, 07 Dec 2017 21:47:12 GMT
       Content-Length:
-      - '550'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:08 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3147,7 +2952,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -3164,123 +2969,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - cd0b88b6-a847-425f-a07b-97afcead677f
+      - 62c5375c-0a02-45a7-bb2e-7edbfcf44774
       X-Ms-Correlation-Request-Id:
-      - cd0b88b6-a847-425f-a07b-97afcead677f
+      - 62c5375c-0a02-45a7-bb2e-7edbfcf44774
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222709Z:cd0b88b6-a847-425f-a07b-97afcead677f
+      - WESTCENTRALUS:20171207T214713Z:62c5375c-0a02-45a7-bb2e-7edbfcf44774
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:08 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 92d471fb-7b1e-4249-9615-d7d2289f7b1e
-      X-Ms-Correlation-Request-Id:
-      - 92d471fb-7b1e-4249-9615-d7d2289f7b1e
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222710Z:92d471fb-7b1e-4249-9615-d7d2289f7b1e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:09 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 50a94c9a-c4f0-409a-a1ec-626d16632b82
-      X-Ms-Correlation-Request-Id:
-      - 50a94c9a-c4f0-409a-a1ec-626d16632b82
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222710Z:50a94c9a-c4f0-409a-a1ec-626d16632b82
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:10 GMT
+      - Thu, 07 Dec 2017 21:47:13 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:10 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:13 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3294,7 +3001,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -3311,25 +3018,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4782d850-f6ea-4d13-a282-2667c2045d47
+      - d58270ec-106f-4fca-a64c-3585b5a5c59a
       X-Ms-Correlation-Request-Id:
-      - 4782d850-f6ea-4d13-a282-2667c2045d47
+      - d58270ec-106f-4fca-a64c-3585b5a5c59a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222711Z:4782d850-f6ea-4d13-a282-2667c2045d47
+      - WESTCENTRALUS:20171207T214713Z:d58270ec-106f-4fca-a64c-3585b5a5c59a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:10 GMT
+      - Thu, 07 Dec 2017 21:47:12 GMT
       Content-Length:
-      - '552'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:11 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3343,7 +3050,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -3360,123 +3067,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 92afe5d9-b00c-4e87-92c4-77e54257734a
+      - 40a41257-8208-435f-8f06-f5d941875883
       X-Ms-Correlation-Request-Id:
-      - 92afe5d9-b00c-4e87-92c4-77e54257734a
+      - 40a41257-8208-435f-8f06-f5d941875883
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222712Z:92afe5d9-b00c-4e87-92c4-77e54257734a
+      - WESTCENTRALUS:20171207T214714Z:40a41257-8208-435f-8f06-f5d941875883
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:11 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7fb72874-9528-4250-a153-8861d5ef9303
-      X-Ms-Correlation-Request-Id:
-      - 7fb72874-9528-4250-a153-8861d5ef9303
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222712Z:7fb72874-9528-4250-a153-8861d5ef9303
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:11 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6738ed4e-ae77-45cb-a096-561692cee814
-      X-Ms-Correlation-Request-Id:
-      - 6738ed4e-ae77-45cb-a096-561692cee814
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222713Z:6738ed4e-ae77-45cb-a096-561692cee814
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:13 GMT
+      - Thu, 07 Dec 2017 21:47:13 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:13 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3490,7 +3099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -3507,25 +3116,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4e36b9e3-f379-408a-81ea-7b9fc2ff6994
+      - f1acc24d-1bd3-44a7-ba18-fc4e91887f3a
       X-Ms-Correlation-Request-Id:
-      - 4e36b9e3-f379-408a-81ea-7b9fc2ff6994
+      - f1acc24d-1bd3-44a7-ba18-fc4e91887f3a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222713Z:4e36b9e3-f379-408a-81ea-7b9fc2ff6994
+      - WESTCENTRALUS:20171207T214715Z:f1acc24d-1bd3-44a7-ba18-fc4e91887f3a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:13 GMT
+      - Thu, 07 Dec 2017 21:47:14 GMT
       Content-Length:
-      - '559'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:14 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3539,7 +3148,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -3556,123 +3165,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 41603944-d311-4654-9160-9505bc65236f
+      - dd3a5f87-655e-49a0-b1aa-1035a651ae52
       X-Ms-Correlation-Request-Id:
-      - 41603944-d311-4654-9160-9505bc65236f
+      - dd3a5f87-655e-49a0-b1aa-1035a651ae52
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222714Z:41603944-d311-4654-9160-9505bc65236f
+      - WESTCENTRALUS:20171207T214715Z:dd3a5f87-655e-49a0-b1aa-1035a651ae52
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:14 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - cb54e01a-ba42-4b97-9754-65dad6e7519c
-      X-Ms-Correlation-Request-Id:
-      - cb54e01a-ba42-4b97-9754-65dad6e7519c
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222715Z:cb54e01a-ba42-4b97-9754-65dad6e7519c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:14 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - cb4f814e-1d40-42ca-9ec6-7f0e31e709c5
-      X-Ms-Correlation-Request-Id:
-      - cb4f814e-1d40-42ca-9ec6-7f0e31e709c5
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222716Z:cb4f814e-1d40-42ca-9ec6-7f0e31e709c5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:15 GMT
+      - Thu, 07 Dec 2017 21:47:15 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:16 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3686,7 +3197,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -3703,25 +3214,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 331cd97b-5e5c-439f-96de-bc213c100336
+      - 0510ac57-0273-494d-ba35-4262ffef56b3
       X-Ms-Correlation-Request-Id:
-      - 331cd97b-5e5c-439f-96de-bc213c100336
+      - 0510ac57-0273-494d-ba35-4262ffef56b3
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222716Z:331cd97b-5e5c-439f-96de-bc213c100336
+      - WESTCENTRALUS:20171207T214715Z:0510ac57-0273-494d-ba35-4262ffef56b3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:16 GMT
+      - Thu, 07 Dec 2017 21:47:14 GMT
       Content-Length:
-      - '553'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:16 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3735,7 +3246,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -3752,123 +3263,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 533c5d72-228a-4ae2-8a6a-84d368151da3
+      - c4de3ad5-5ebb-4e57-ab91-6be483668fba
       X-Ms-Correlation-Request-Id:
-      - 533c5d72-228a-4ae2-8a6a-84d368151da3
+      - c4de3ad5-5ebb-4e57-ab91-6be483668fba
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222717Z:533c5d72-228a-4ae2-8a6a-84d368151da3
+      - WESTCENTRALUS:20171207T214716Z:c4de3ad5-5ebb-4e57-ab91-6be483668fba
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:17 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:17 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - eb733c1e-8067-4509-91c5-0cf66b0d3e0f
-      X-Ms-Correlation-Request-Id:
-      - eb733c1e-8067-4509-91c5-0cf66b0d3e0f
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222718Z:eb733c1e-8067-4509-91c5-0cf66b0d3e0f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:17 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:18 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f881ad5e-a543-42e3-8c6d-447d6f39debc
-      X-Ms-Correlation-Request-Id:
-      - f881ad5e-a543-42e3-8c6d-447d6f39debc
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222718Z:f881ad5e-a543-42e3-8c6d-447d6f39debc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:18 GMT
+      - Thu, 07 Dec 2017 21:47:15 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:19 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3882,7 +3295,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -3899,25 +3312,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0f2ba297-9cf8-483f-9c1c-10cb067835ba
+      - 5c156a8d-4c63-4c93-8482-8186f7a79e1a
       X-Ms-Correlation-Request-Id:
-      - 0f2ba297-9cf8-483f-9c1c-10cb067835ba
+      - 5c156a8d-4c63-4c93-8482-8186f7a79e1a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222719Z:0f2ba297-9cf8-483f-9c1c-10cb067835ba
+      - WESTCENTRALUS:20171207T214716Z:5c156a8d-4c63-4c93-8482-8186f7a79e1a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:19 GMT
+      - Thu, 07 Dec 2017 21:47:15 GMT
       Content-Length:
-      - '554'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:19 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3931,7 +3344,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -3948,123 +3361,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f421f00b-b6bf-4c4f-946e-d0402a04e217
+      - ff7548ea-1e2c-4db1-ba28-87815382f730
       X-Ms-Correlation-Request-Id:
-      - f421f00b-b6bf-4c4f-946e-d0402a04e217
+      - ff7548ea-1e2c-4db1-ba28-87815382f730
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222720Z:f421f00b-b6bf-4c4f-946e-d0402a04e217
+      - WESTCENTRALUS:20171207T214717Z:ff7548ea-1e2c-4db1-ba28-87815382f730
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:20 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:20 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4c8e3cf2-98e0-4434-bb35-fcb229b8bc1a
-      X-Ms-Correlation-Request-Id:
-      - 4c8e3cf2-98e0-4434-bb35-fcb229b8bc1a
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222720Z:4c8e3cf2-98e0-4434-bb35-fcb229b8bc1a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:20 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2ef0f81b-5599-4976-8fae-6a91e52aa58d
-      X-Ms-Correlation-Request-Id:
-      - 2ef0f81b-5599-4976-8fae-6a91e52aa58d
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222721Z:2ef0f81b-5599-4976-8fae-6a91e52aa58d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:20 GMT
+      - Thu, 07 Dec 2017 21:47:16 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:21 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4078,7 +3393,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -4095,25 +3410,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5bc51b25-c00c-4759-bbd1-09bc6eccbcf3
+      - ba9064dd-0315-4b42-9c2d-e7cb94da36b5
       X-Ms-Correlation-Request-Id:
-      - 5bc51b25-c00c-4759-bbd1-09bc6eccbcf3
+      - ba9064dd-0315-4b42-9c2d-e7cb94da36b5
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222722Z:5bc51b25-c00c-4759-bbd1-09bc6eccbcf3
+      - WESTCENTRALUS:20171207T214717Z:ba9064dd-0315-4b42-9c2d-e7cb94da36b5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:21 GMT
+      - Thu, 07 Dec 2017 21:47:16 GMT
       Content-Length:
-      - '548'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:22 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4127,7 +3442,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -4144,123 +3459,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6d52bed3-5dc7-4ea6-a903-933788e3dbab
+      - 95b01040-78d8-4265-b510-fd0e8664b976
       X-Ms-Correlation-Request-Id:
-      - 6d52bed3-5dc7-4ea6-a903-933788e3dbab
+      - 95b01040-78d8-4265-b510-fd0e8664b976
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222722Z:6d52bed3-5dc7-4ea6-a903-933788e3dbab
+      - WESTCENTRALUS:20171207T214717Z:95b01040-78d8-4265-b510-fd0e8664b976
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:22 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 942d721d-a4d8-4ff6-8eef-b1760bfa86eb
-      X-Ms-Correlation-Request-Id:
-      - 942d721d-a4d8-4ff6-8eef-b1760bfa86eb
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222723Z:942d721d-a4d8-4ff6-8eef-b1760bfa86eb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:23 GMT
-      Content-Length:
-      - '547'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 455a1ff3-bade-491a-b3a1-0aeb66d6c654
-      X-Ms-Correlation-Request-Id:
-      - 455a1ff3-bade-491a-b3a1-0aeb66d6c654
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222724Z:455a1ff3-bade-491a-b3a1-0aeb66d6c654
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:24 GMT
+      - Thu, 07 Dec 2017 21:47:17 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:24 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4274,7 +3491,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -4291,25 +3508,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e6ee798f-7cfc-4b37-8416-ce308e27068e
+      - 82c123f6-522a-4daf-a1ec-1e91e88e07b9
       X-Ms-Correlation-Request-Id:
-      - e6ee798f-7cfc-4b37-8416-ce308e27068e
+      - 82c123f6-522a-4daf-a1ec-1e91e88e07b9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222725Z:e6ee798f-7cfc-4b37-8416-ce308e27068e
+      - WESTCENTRALUS:20171207T214718Z:82c123f6-522a-4daf-a1ec-1e91e88e07b9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:24 GMT
+      - Thu, 07 Dec 2017 21:47:17 GMT
       Content-Length:
-      - '554'
+      - '575'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:25 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4323,7 +3540,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -4340,123 +3557,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d9b4afce-62de-4440-9867-4b9bfcf830b4
+      - af309487-8506-46f1-a7c8-fc05cdaaad42
       X-Ms-Correlation-Request-Id:
-      - d9b4afce-62de-4440-9867-4b9bfcf830b4
+      - af309487-8506-46f1-a7c8-fc05cdaaad42
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222725Z:d9b4afce-62de-4440-9867-4b9bfcf830b4
+      - WESTCENTRALUS:20171207T214718Z:af309487-8506-46f1-a7c8-fc05cdaaad42
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:24 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7db7885e-e6dd-42ec-b44b-0f4853d2f0b3
-      X-Ms-Correlation-Request-Id:
-      - 7db7885e-e6dd-42ec-b44b-0f4853d2f0b3
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222726Z:7db7885e-e6dd-42ec-b44b-0f4853d2f0b3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:25 GMT
-      Content-Length:
-      - '548'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - c45887e7-38be-4fa7-b496-c88c31d4f65d
-      X-Ms-Correlation-Request-Id:
-      - c45887e7-38be-4fa7-b496-c88c31d4f65d
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222726Z:c45887e7-38be-4fa7-b496-c88c31d4f65d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:26 GMT
+      - Thu, 07 Dec 2017 21:47:18 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:26 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4470,7 +3589,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -4487,25 +3606,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 76accd59-dd72-488e-bfd9-0fb767bfa11d
+      - 89184fd4-0e7e-4a41-9451-a1e3a29406ed
       X-Ms-Correlation-Request-Id:
-      - 76accd59-dd72-488e-bfd9-0fb767bfa11d
+      - 89184fd4-0e7e-4a41-9451-a1e3a29406ed
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222728Z:76accd59-dd72-488e-bfd9-0fb767bfa11d
+      - WESTCENTRALUS:20171207T214718Z:89184fd4-0e7e-4a41-9451-a1e3a29406ed
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:27 GMT
+      - Thu, 07 Dec 2017 21:47:18 GMT
       Content-Length:
-      - '553'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:28 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:19 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4519,7 +3638,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
   response:
     status:
       code: 200
@@ -4536,118 +3655,1000 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5bd84478-a550-4c20-b38e-6a9ea10fe7eb
+      - 356f3adf-43fb-4bea-9867-367a3521e3ab
       X-Ms-Correlation-Request-Id:
-      - 5bd84478-a550-4c20-b38e-6a9ea10fe7eb
+      - 356f3adf-43fb-4bea-9867-367a3521e3ab
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222728Z:5bd84478-a550-4c20-b38e-6a9ea10fe7eb
+      - WESTCENTRALUS:20171207T214719Z:356f3adf-43fb-4bea-9867-367a3521e3ab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:27:28 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1345b0a5-075b-4541-a4f6-9002a58a050b
-      X-Ms-Correlation-Request-Id:
-      - 1345b0a5-075b-4541-a4f6-9002a58a050b
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222729Z:1345b0a5-075b-4541-a4f6-9002a58a050b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:29 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjY5MTIsIm5iZiI6MTUxMjE2NjkxMiwiZXhwIjoxNTEyMTcwODEyLCJhaW8iOiJZMk5nWUhqWmtaWHlyYzF1MDdGOUNaOU5qMHJ4QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVHdITGFIcHFTazY4dEdTWGV6UXJBQSIsInZlciI6IjEuMCJ9.aNZCcTbpbYKPH-SAcJmsQbiwV0kAgez2i-2KvfpCJpY7_vVIbhFq-qcrKi_zwjOQMBxM1u1Au1MAJtebqitmAx1-jTfYS5qqP8P52v8ULemGG5Z-1lm0tY-K9Z0fCzzUe_5fXpSJ4IvyZYlvIZ-qTx5aMsMWFjDIsZfMkpZakvik8abKJDYa9U3DZiujh0Ty3FEEnerdr0qo0MbYgmEbM-XUXy0pbWM6m6Ea_espZ7K9Wie_QEnSgNwyCPOwPcy6B1YR9CeblFkWSAitsG7km5PQ6FPrGjjQdOKoLbA6p7ZRa_BFoQT7sNOiEJOPu9M79-CgDcGOLo2rqrBvfRMf3Q
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2ea9d0bb-b873-4235-a75b-18bb70792557
-      X-Ms-Correlation-Request-Id:
-      - 2ea9d0bb-b873-4235-a75b-18bb70792557
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222730Z:2ea9d0bb-b873-4235-a75b-18bb70792557
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:27:29 GMT
+      - Thu, 07 Dec 2017 21:47:18 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:27:30 GMT
+  recorded_at: Thu, 07 Dec 2017 21:47:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 65339f81-6752-4e7a-85ec-f09bc031b452
+      X-Ms-Correlation-Request-Id:
+      - 65339f81-6752-4e7a-85ec-f09bc031b452
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214719Z:65339f81-6752-4e7a-85ec-f09bc031b452
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:19 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b6d621e9-9f0c-4ea5-a259-501ed9b2d507
+      X-Ms-Correlation-Request-Id:
+      - b6d621e9-9f0c-4ea5-a259-501ed9b2d507
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214720Z:b6d621e9-9f0c-4ea5-a259-501ed9b2d507
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:19 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 23816104-9d92-4963-b198-461bad4152fe
+      X-Ms-Correlation-Request-Id:
+      - 23816104-9d92-4963-b198-461bad4152fe
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214720Z:23816104-9d92-4963-b198-461bad4152fe
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:19 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5045edc1-fcd3-4a7b-9bee-a9bd29beda1d
+      X-Ms-Correlation-Request-Id:
+      - 5045edc1-fcd3-4a7b-9bee-a9bd29beda1d
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214721Z:5045edc1-fcd3-4a7b-9bee-a9bd29beda1d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:20 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a3d26fb5-47be-4cd2-948a-752932ec1d4c
+      X-Ms-Correlation-Request-Id:
+      - a3d26fb5-47be-4cd2-948a-752932ec1d4c
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214721Z:a3d26fb5-47be-4cd2-948a-752932ec1d4c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:20 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b4b128db-85c9-45fb-a44b-984f023f1225
+      X-Ms-Correlation-Request-Id:
+      - b4b128db-85c9-45fb-a44b-984f023f1225
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214721Z:b4b128db-85c9-45fb-a44b-984f023f1225
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:21 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c3c393fc-23e1-42a4-9bc3-70d526f5d45e
+      X-Ms-Correlation-Request-Id:
+      - c3c393fc-23e1-42a4-9bc3-70d526f5d45e
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214722Z:c3c393fc-23e1-42a4-9bc3-70d526f5d45e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:22 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - efde1102-7701-4502-8511-bef62f8f71f5
+      X-Ms-Correlation-Request-Id:
+      - efde1102-7701-4502-8511-bef62f8f71f5
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214722Z:efde1102-7701-4502-8511-bef62f8f71f5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:21 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - cdb51512-3f33-4bd0-b877-58b0490c520f
+      X-Ms-Correlation-Request-Id:
+      - cdb51512-3f33-4bd0-b877-58b0490c520f
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214723Z:cdb51512-3f33-4bd0-b877-58b0490c520f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:22 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f81858be-92bf-44c4-bb14-8fb927c70545
+      X-Ms-Correlation-Request-Id:
+      - f81858be-92bf-44c4-bb14-8fb927c70545
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214723Z:f81858be-92bf-44c4-bb14-8fb927c70545
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:23 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 974f0ab4-268c-4660-aa87-6a338e050669
+      X-Ms-Correlation-Request-Id:
+      - 974f0ab4-268c-4660-aa87-6a338e050669
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214723Z:974f0ab4-268c-4660-aa87-6a338e050669
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:23 GMT
+      Content-Length:
+      - '563'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4eb1ba65-cefc-4e91-80ac-84a04060972b
+      X-Ms-Correlation-Request-Id:
+      - 4eb1ba65-cefc-4e91-80ac-84a04060972b
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214724Z:4eb1ba65-cefc-4e91-80ac-84a04060972b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:24 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5824e94b-e498-4ea9-b204-53ca3ea5718c
+      X-Ms-Correlation-Request-Id:
+      - 5824e94b-e498-4ea9-b204-53ca3ea5718c
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214724Z:5824e94b-e498-4ea9-b204-53ca3ea5718c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:23 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 20cb7436-983a-4d14-97b3-d8f6b5e27f22
+      X-Ms-Correlation-Request-Id:
+      - 20cb7436-983a-4d14-97b3-d8f6b5e27f22
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214725Z:20cb7436-983a-4d14-97b3-d8f6b5e27f22
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:24 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 39a8e33a-1499-4b68-8214-ecb6af0a0ad3
+      X-Ms-Correlation-Request-Id:
+      - 39a8e33a-1499-4b68-8214-ecb6af0a0ad3
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214725Z:39a8e33a-1499-4b68-8214-ecb6af0a0ad3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:25 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1f57e869-5168-4749-8105-7fd3454d2a0c
+      X-Ms-Correlation-Request-Id:
+      - 1f57e869-5168-4749-8105-7fd3454d2a0c
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214726Z:1f57e869-5168-4749-8105-7fd3454d2a0c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:26 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4130ba6e-c734-48c0-91fa-0adfa0926818
+      X-Ms-Correlation-Request-Id:
+      - 4130ba6e-c734-48c0-91fa-0adfa0926818
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214726Z:4130ba6e-c734-48c0-91fa-0adfa0926818
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:25 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7a3fd9de-96be-4cfc-9325-a684dbf5bde5
+      X-Ms-Correlation-Request-Id:
+      - 7a3fd9de-96be-4cfc-9325-a684dbf5bde5
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214727Z:7a3fd9de-96be-4cfc-9325-a684dbf5bde5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:26 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - bfe85aa6-133b-4e1a-a32a-8e0cab498a43
+      X-Ms-Correlation-Request-Id:
+      - bfe85aa6-133b-4e1a-a32a-8e0cab498a43
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214727Z:bfe85aa6-133b-4e1a-a32a-8e0cab498a43
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:27 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5MjQsIm5iZiI6MTUxMjY4MjkyNCwiZXhwIjoxNTEyNjg2ODI0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiekEtZ2VDV2RVMFdMU3d3ZWVUUU1BQSIsInZlciI6IjEuMCJ9.TtpxjM4_KxZlG7Yax0MDJkWNyPr2_45GnslMeO8oF-81s5Gj_wKZpwZRlbyYBGKOE9Nqi461jSH72Bfc4c7ErAqExSUdsTIYdNmvPswJb92uWr1lmHj09wDVPrtUYv8f7sbzVWoxUQwt5S-4XNNDqP1e3t4FAnU7v-09Lz8mDarFjtIpC5PI6wAWObI6A0cNo2F--6mA20k0WGGgJNrFHM3x2Yx-fgrcHbsojMLvoZRSIgpzj2DnaEMPLJxUtPmTXBsk4bXRTTMsDUiY3MB2pFcfqmXJGeXMU8vRVGedu9MLmWm0QhdrL2oy2xifu_Dr_3qgwAM7kTdW6Qyrja7iWg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7781c81c-f0c3-4a62-a0a2-f630dc9f7ccb
+      X-Ms-Correlation-Request-Id:
+      - 7781c81c-f0c3-4a62-a0a2-f630dc9f7ccb
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214728Z:7781c81c-f0c3-4a62-a0a2-f630dc9f7ccb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:47:28 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:47:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 1fcda750-68f1-44a2-90a9-80d3c3162a00
+      - '08e319b7-3c78-48c2-8777-1f025d260c00'
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzXP8RQ6h9jypHvRqnwfybsepnIhYQvZQ2ql4iIDzASOqcUtizKQWuusHU9co7xEhwvwRzxu5iYe3bSHXYKYXc0fEzttLWAP9rcpnqIrBlHTzGT2OWxYNfuQT0ahknkomyKaD1WzcuCeGYch8nJ9iGT25DQxwUJyFEHR4Zqf0g32cgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzGLq_i0yDA7BgAH9lykU8Ewv_UcmAK8wHHSnTuzlWSVcnyexbUCGDtCyWVVsP4hisEg799Czc97HhV-EP-mD-OHXvePxAX8GkHIgYnf8MOCIL5OHz9il3pfnN_2vfyxqbAA4QBn_gKgyRpxGWB2qlfMzKyj3tjct9Y7b99IdmWMEgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 01 Dec 2017 22:28:46 GMT
+      - Thu, 07 Dec 2017 21:49:03 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1512170927","not_before":"1512167027","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1512686945","not_before":"1512683045","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:47 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:05 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -91,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14997'
       X-Ms-Request-Id:
-      - fe293894-65af-476a-a75d-dedf61180102
+      - 7bde5243-e95c-4545-8e1c-4259e96adb22
       X-Ms-Correlation-Request-Id:
-      - fe293894-65af-476a-a75d-dedf61180102
+      - 7bde5243-e95c-4545-8e1c-4259e96adb22
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222847Z:fe293894-65af-476a-a75d-dedf61180102
+      - WESTCENTRALUS:20171207T214905Z:7bde5243-e95c-4545-8e1c-4259e96adb22
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:47 GMT
+      - Thu, 07 Dec 2017 21:49:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:47 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:05 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -124,7 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -141,19 +141,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14936'
+      - '13723'
       X-Ms-Request-Id:
-      - 45efe514-3c60-4086-9493-2622f39df8e2
+      - 16fb86f5-9ddb-4813-838e-d6865acda400
       X-Ms-Correlation-Request-Id:
-      - 45efe514-3c60-4086-9493-2622f39df8e2
+      - 16fb86f5-9ddb-4813-838e-d6865acda400
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222848Z:45efe514-3c60-4086-9493-2622f39df8e2
+      - WESTCENTRALUS:20171207T214906Z:16fb86f5-9ddb-4813-838e-d6865acda400
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:48 GMT
+      - Thu, 07 Dec 2017 21:49:05 GMT
       Content-Length:
-      - '278554'
+      - '279208'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -260,7 +260,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -491,7 +491,7 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
-        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
         US","UK West","West India","Australia East","Brazil South","Canada East","East
@@ -614,92 +614,92 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","North
         Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
         South","Japan East","Japan West","North Europe","West Europe","Central India","South
@@ -816,7 +816,7 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
@@ -1459,7 +1459,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1606,7 +1606,8 @@ http_interactions:
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
@@ -1873,23 +1874,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1938,8 +1939,8 @@ http_interactions:
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
         Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
-        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"operations","locations":["Central
-        US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
@@ -2017,8 +2018,8 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -2030,18 +2031,18 @@ http_interactions:
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
@@ -2122,7 +2123,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:48 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:06 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/locations?api-version=2015-01-01
@@ -2139,7 +2140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2156,17 +2157,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14936'
+      - '14962'
       X-Ms-Request-Id:
-      - a243f91c-7962-474c-a223-755233237f2e
+      - 1a043773-8bc8-4371-b78e-63e242a40197
       X-Ms-Correlation-Request-Id:
-      - a243f91c-7962-474c-a223-755233237f2e
+      - 1a043773-8bc8-4371-b78e-63e242a40197
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222849Z:a243f91c-7962-474c-a223-755233237f2e
+      - WESTCENTRALUS:20171207T214906Z:1a043773-8bc8-4371-b78e-63e242a40197
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:49 GMT
+      - Thu, 07 Dec 2017 21:49:06 GMT
       Content-Length:
       - '4523'
     body:
@@ -2199,10 +2200,10 @@ http_interactions:
         Central","longitude":"126.9780","latitude":"37.5665"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/locations/koreasouth","name":"koreasouth","displayName":"Korea
         South","longitude":"129.0756","latitude":"35.1796"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:49 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2216,7 +2217,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2233,25 +2234,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9f41586c-267f-41ba-a5a6-ba08bdf3b0e8
+      - ed29412d-0773-47c8-9404-fcc942726777
       X-Ms-Correlation-Request-Id:
-      - 9f41586c-267f-41ba-a5a6-ba08bdf3b0e8
+      - ed29412d-0773-47c8-9404-fcc942726777
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222850Z:9f41586c-267f-41ba-a5a6-ba08bdf3b0e8
+      - WESTCENTRALUS:20171207T214907Z:ed29412d-0773-47c8-9404-fcc942726777
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:49 GMT
+      - Thu, 07 Dec 2017 21:49:06 GMT
       Content-Length:
-      - '549'
+      - '565'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:50 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2265,7 +2266,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2282,123 +2283,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 98be67d6-68b3-4b30-b334-ea0ba70a2826
+      - 7504df2a-852c-4e45-b320-6c58c44f522a
       X-Ms-Correlation-Request-Id:
-      - 98be67d6-68b3-4b30-b334-ea0ba70a2826
+      - 7504df2a-852c-4e45-b320-6c58c44f522a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222850Z:98be67d6-68b3-4b30-b334-ea0ba70a2826
+      - WESTCENTRALUS:20171207T214907Z:7504df2a-852c-4e45-b320-6c58c44f522a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:49 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e216b23b-11b5-4d94-8365-ce9688399081
-      X-Ms-Correlation-Request-Id:
-      - e216b23b-11b5-4d94-8365-ce9688399081
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222851Z:e216b23b-11b5-4d94-8365-ce9688399081
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:51 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7d79973d-276e-446d-ad5d-1196d4867ba1
-      X-Ms-Correlation-Request-Id:
-      - 7d79973d-276e-446d-ad5d-1196d4867ba1
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222852Z:7d79973d-276e-446d-ad5d-1196d4867ba1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:51 GMT
+      - Thu, 07 Dec 2017 21:49:07 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:52 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2412,7 +2315,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2429,25 +2332,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7a337aec-afd6-42c6-9981-e2cca40fe312
+      - 8007815c-a5ec-459b-8846-bcb163b56569
       X-Ms-Correlation-Request-Id:
-      - 7a337aec-afd6-42c6-9981-e2cca40fe312
+      - 8007815c-a5ec-459b-8846-bcb163b56569
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222852Z:7a337aec-afd6-42c6-9981-e2cca40fe312
+      - WESTCENTRALUS:20171207T214908Z:8007815c-a5ec-459b-8846-bcb163b56569
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:52 GMT
+      - Thu, 07 Dec 2017 21:49:07 GMT
       Content-Length:
-      - '550'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:52 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2461,7 +2364,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2478,25 +2381,123 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 43468550-1932-4ca7-b53e-b2d942782ffb
+      - bbe27bd1-9109-4554-a9f0-ae74d2bf3378
       X-Ms-Correlation-Request-Id:
-      - 43468550-1932-4ca7-b53e-b2d942782ffb
+      - bbe27bd1-9109-4554-a9f0-ae74d2bf3378
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222853Z:43468550-1932-4ca7-b53e-b2d942782ffb
+      - WESTCENTRALUS:20171207T214908Z:bbe27bd1-9109-4554-a9f0-ae74d2bf3378
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:53 GMT
+      - Thu, 07 Dec 2017 21:49:08 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 86455711-37e7-4ab1-ace5-a81826c20f41
+      X-Ms-Correlation-Request-Id:
+      - 86455711-37e7-4ab1-ace5-a81826c20f41
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214909Z:86455711-37e7-4ab1-ace5-a81826c20f41
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:08 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b245185d-de39-4b9d-bd26-a3c2ae04fff3
+      X-Ms-Correlation-Request-Id:
+      - b245185d-de39-4b9d-bd26-a3c2ae04fff3
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214909Z:b245185d-de39-4b9d-bd26-a3c2ae04fff3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:08 GMT
       Content-Length:
       - '1104'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2","name":"jf-metrics-2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3","name":"jf-metrics-3","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1","name":"miqazure-oraclelinux1","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2","name":"miqazure-oraclelinux2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"false"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:53 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2510,7 +2511,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2527,25 +2528,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7dd75f47-4f5c-4944-ae03-c2782539d1f0
+      - d5b1a2be-a17b-4b1f-95f9-0872556e667f
       X-Ms-Correlation-Request-Id:
-      - 7dd75f47-4f5c-4944-ae03-c2782539d1f0
+      - d5b1a2be-a17b-4b1f-95f9-0872556e667f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222854Z:7dd75f47-4f5c-4944-ae03-c2782539d1f0
+      - WESTCENTRALUS:20171207T214910Z:d5b1a2be-a17b-4b1f-95f9-0872556e667f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:53 GMT
+      - Thu, 07 Dec 2017 21:49:09 GMT
       Content-Length:
-      - '547'
+      - '563'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:54 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2559,7 +2560,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2576,25 +2577,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a5827ab3-a2e6-4ecf-927d-a8b50e3732a8
+      - 6969e82b-6f2f-4922-8d34-d19d395f2ef0
       X-Ms-Correlation-Request-Id:
-      - a5827ab3-a2e6-4ecf-927d-a8b50e3732a8
+      - 6969e82b-6f2f-4922-8d34-d19d395f2ef0
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222855Z:a5827ab3-a2e6-4ecf-927d-a8b50e3732a8
+      - WESTCENTRALUS:20171207T214910Z:6969e82b-6f2f-4922-8d34-d19d395f2ef0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:54 GMT
+      - Thu, 07 Dec 2017 21:49:09 GMT
       Content-Length:
       - '3378'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","name":"miq-test-rhel1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","name":"miq-test-ubuntu1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","name":"miq-test-win12","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","name":"miq-test-winimg","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","name":"miqazure-centos1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","name":"rspec-lb-a","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","name":"rspec-lb-b","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","name":"spec0deply1vm0","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","name":"spec0deply1vm1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2","name":"miqmismatch2","type":"Microsoft.Compute/virtualMachines","location":"eastus","plan":{"name":"rhel74","product":"rhel-byol-preview","publisher":"redhat"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/dbergerprov1","name":"dbergerprov1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","name":"miqazure-linux-managed","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1","name":"miqmismatch1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:55 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2608,7 +2609,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2625,25 +2626,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3a768707-153c-4700-88e9-aa0d22cd122e
+      - 873b13db-04d3-4bfd-9bf5-3055da9de7ba
       X-Ms-Correlation-Request-Id:
-      - 3a768707-153c-4700-88e9-aa0d22cd122e
+      - 873b13db-04d3-4bfd-9bf5-3055da9de7ba
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222855Z:3a768707-153c-4700-88e9-aa0d22cd122e
+      - WESTCENTRALUS:20171207T214911Z:873b13db-04d3-4bfd-9bf5-3055da9de7ba
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:55 GMT
+      - Thu, 07 Dec 2017 21:49:10 GMT
       Content-Length:
-      - '548'
+      - '564'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:56 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2657,7 +2658,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2674,25 +2675,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - abc49d66-95bc-4dca-b75d-95f1083feded
+      - 9800a48e-dd17-4a8e-a748-49c72fcc5823
       X-Ms-Correlation-Request-Id:
-      - abc49d66-95bc-4dca-b75d-95f1083feded
+      - 9800a48e-dd17-4a8e-a748-49c72fcc5823
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222856Z:abc49d66-95bc-4dca-b75d-95f1083feded
+      - WESTCENTRALUS:20171207T214911Z:9800a48e-dd17-4a8e-a748-49c72fcc5823
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:56 GMT
+      - Thu, 07 Dec 2017 21:49:10 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:56 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2706,7 +2707,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2723,25 +2724,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b27a00e9-f683-4d41-9fd3-041445e76fa8
+      - 83e749e0-45e4-4d98-8e6d-95298f2a3afe
       X-Ms-Correlation-Request-Id:
-      - b27a00e9-f683-4d41-9fd3-041445e76fa8
+      - 83e749e0-45e4-4d98-8e6d-95298f2a3afe
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222857Z:b27a00e9-f683-4d41-9fd3-041445e76fa8
+      - WESTCENTRALUS:20171207T214911Z:83e749e0-45e4-4d98-8e6d-95298f2a3afe
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:56 GMT
+      - Thu, 07 Dec 2017 21:49:11 GMT
       Content-Length:
-      - '547'
+      - '563'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:57 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2755,7 +2756,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2772,25 +2773,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6feef107-46e8-47a9-a3eb-47a836930f4d
+      - 562e99a4-ce25-4a5f-bc7a-a29ae51c5ee4
       X-Ms-Correlation-Request-Id:
-      - 6feef107-46e8-47a9-a3eb-47a836930f4d
+      - 562e99a4-ce25-4a5f-bc7a-a29ae51c5ee4
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222857Z:6feef107-46e8-47a9-a3eb-47a836930f4d
+      - WESTCENTRALUS:20171207T214912Z:562e99a4-ce25-4a5f-bc7a-a29ae51c5ee4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:57 GMT
+      - Thu, 07 Dec 2017 21:49:11 GMT
       Content-Length:
       - '280'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1","name":"miqazure-coreos1","type":"Microsoft.Compute/virtualMachines","location":"westus","tags":{"Shutdown":"true"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:58 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2804,7 +2805,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2821,25 +2822,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 32b3aecf-cd98-463c-8d05-6a1cc15c954c
+      - 2caf6487-9fa8-4cd2-b53c-0474ff760200
       X-Ms-Correlation-Request-Id:
-      - 32b3aecf-cd98-463c-8d05-6a1cc15c954c
+      - 2caf6487-9fa8-4cd2-b53c-0474ff760200
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222858Z:32b3aecf-cd98-463c-8d05-6a1cc15c954c
+      - WESTCENTRALUS:20171207T214912Z:2caf6487-9fa8-4cd2-b53c-0474ff760200
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:58 GMT
+      - Thu, 07 Dec 2017 21:49:12 GMT
       Content-Length:
-      - '555'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:58 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2853,7 +2854,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -2870,123 +2871,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0e1e9402-b3bb-4ea3-829c-bb565934d7eb
+      - e0984410-4b6b-4071-ba27-8bb1bd581639
       X-Ms-Correlation-Request-Id:
-      - 0e1e9402-b3bb-4ea3-829c-bb565934d7eb
+      - e0984410-4b6b-4071-ba27-8bb1bd581639
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222859Z:0e1e9402-b3bb-4ea3-829c-bb565934d7eb
+      - WESTCENTRALUS:20171207T214913Z:e0984410-4b6b-4071-ba27-8bb1bd581639
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:28:58 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:28:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 366ae703-1dba-44df-9377-92996e468ee8
-      X-Ms-Correlation-Request-Id:
-      - 366ae703-1dba-44df-9377-92996e468ee8
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222900Z:366ae703-1dba-44df-9377-92996e468ee8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:59 GMT
-      Content-Length:
-      - '555'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8d322375-3f8d-4a16-a95b-e5842dc8121f
-      X-Ms-Correlation-Request-Id:
-      - 8d322375-3f8d-4a16-a95b-e5842dc8121f
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222900Z:8d322375-3f8d-4a16-a95b-e5842dc8121f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:28:59 GMT
+      - Thu, 07 Dec 2017 21:49:12 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:00 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:13 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3000,7 +2903,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3017,25 +2920,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5ccc086b-4434-48bd-979b-e36a7c33de6d
+      - 7a7b9568-a63d-46d0-9b5a-ddf12850c71c
       X-Ms-Correlation-Request-Id:
-      - 5ccc086b-4434-48bd-979b-e36a7c33de6d
+      - 7a7b9568-a63d-46d0-9b5a-ddf12850c71c
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222901Z:5ccc086b-4434-48bd-979b-e36a7c33de6d
+      - WESTCENTRALUS:20171207T214913Z:7a7b9568-a63d-46d0-9b5a-ddf12850c71c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:00 GMT
+      - Thu, 07 Dec 2017 21:49:12 GMT
       Content-Length:
-      - '552'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:01 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:13 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3049,7 +2952,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3066,123 +2969,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 31e9124c-0ed1-470f-8603-1a761c42d8e6
+      - 4b3d5aa5-d7ff-4248-9860-c8bc4486c5a9
       X-Ms-Correlation-Request-Id:
-      - 31e9124c-0ed1-470f-8603-1a761c42d8e6
+      - 4b3d5aa5-d7ff-4248-9860-c8bc4486c5a9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222902Z:31e9124c-0ed1-470f-8603-1a761c42d8e6
+      - WESTCENTRALUS:20171207T214913Z:4b3d5aa5-d7ff-4248-9860-c8bc4486c5a9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:01 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4ea6f62f-0d50-47f4-9720-30293602d38f
-      X-Ms-Correlation-Request-Id:
-      - 4ea6f62f-0d50-47f4-9720-30293602d38f
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222903Z:4ea6f62f-0d50-47f4-9720-30293602d38f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:02 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - '091745a5-5864-402c-badb-e8c53a8e297d'
-      X-Ms-Correlation-Request-Id:
-      - '091745a5-5864-402c-badb-e8c53a8e297d'
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222904Z:091745a5-5864-402c-badb-e8c53a8e297d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:03 GMT
+      - Thu, 07 Dec 2017 21:49:13 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:04 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3196,7 +3001,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3213,25 +3018,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6d7f19c5-832d-4275-af63-b963b75fba9b
+      - d94c87a1-7644-4ae1-a5ad-708c9ca934d1
       X-Ms-Correlation-Request-Id:
-      - 6d7f19c5-832d-4275-af63-b963b75fba9b
+      - d94c87a1-7644-4ae1-a5ad-708c9ca934d1
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222904Z:6d7f19c5-832d-4275-af63-b963b75fba9b
+      - WESTCENTRALUS:20171207T214914Z:d94c87a1-7644-4ae1-a5ad-708c9ca934d1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:04 GMT
+      - Thu, 07 Dec 2017 21:49:13 GMT
       Content-Length:
-      - '550'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:04 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3245,7 +3050,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3262,123 +3067,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 279df1e7-5ad9-40dc-817f-c12b5448abeb
+      - 9ce0c13e-05e9-4889-b46b-5541fc508d02
       X-Ms-Correlation-Request-Id:
-      - 279df1e7-5ad9-40dc-817f-c12b5448abeb
+      - 9ce0c13e-05e9-4889-b46b-5541fc508d02
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222905Z:279df1e7-5ad9-40dc-817f-c12b5448abeb
+      - WESTCENTRALUS:20171207T214914Z:9ce0c13e-05e9-4889-b46b-5541fc508d02
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:04 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1bc4dfc0-7fde-41bd-ad36-dd8758e15c7c
-      X-Ms-Correlation-Request-Id:
-      - 1bc4dfc0-7fde-41bd-ad36-dd8758e15c7c
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222905Z:1bc4dfc0-7fde-41bd-ad36-dd8758e15c7c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:05 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 12b19ace-752e-4d55-b4f7-7736b28a86dc
-      X-Ms-Correlation-Request-Id:
-      - 12b19ace-752e-4d55-b4f7-7736b28a86dc
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222906Z:12b19ace-752e-4d55-b4f7-7736b28a86dc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:06 GMT
+      - Thu, 07 Dec 2017 21:49:13 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:06 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3392,7 +3099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3409,25 +3116,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 146eea2a-e9d2-4627-9223-baed871a28aa
+      - 110fd073-06ca-4ae4-8b91-4492982c9b7a
       X-Ms-Correlation-Request-Id:
-      - 146eea2a-e9d2-4627-9223-baed871a28aa
+      - 110fd073-06ca-4ae4-8b91-4492982c9b7a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222907Z:146eea2a-e9d2-4627-9223-baed871a28aa
+      - WESTCENTRALUS:20171207T214915Z:110fd073-06ca-4ae4-8b91-4492982c9b7a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:06 GMT
+      - Thu, 07 Dec 2017 21:49:14 GMT
       Content-Length:
-      - '552'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:07 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3441,7 +3148,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3458,123 +3165,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 479cf800-e648-4225-b2d1-1fefc4ceed2a
+      - 0a634277-ed06-4091-a140-543ccda86067
       X-Ms-Correlation-Request-Id:
-      - 479cf800-e648-4225-b2d1-1fefc4ceed2a
+      - 0a634277-ed06-4091-a140-543ccda86067
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222907Z:479cf800-e648-4225-b2d1-1fefc4ceed2a
+      - WESTCENTRALUS:20171207T214915Z:0a634277-ed06-4091-a140-543ccda86067
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:07 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2b7392d3-a2b4-4227-9270-d9a35f22ebe8
-      X-Ms-Correlation-Request-Id:
-      - 2b7392d3-a2b4-4227-9270-d9a35f22ebe8
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222908Z:2b7392d3-a2b4-4227-9270-d9a35f22ebe8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:07 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1122b292-8dd8-4f4d-a322-792f49617f17
-      X-Ms-Correlation-Request-Id:
-      - 1122b292-8dd8-4f4d-a322-792f49617f17
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222909Z:1122b292-8dd8-4f4d-a322-792f49617f17
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:08 GMT
+      - Thu, 07 Dec 2017 21:49:14 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:09 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3588,7 +3197,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3605,25 +3214,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - da64b2aa-63f2-45f1-8083-ac0e665f77b8
+      - 937f912c-7bcb-49bc-9ee5-c2e5115be884
       X-Ms-Correlation-Request-Id:
-      - da64b2aa-63f2-45f1-8083-ac0e665f77b8
+      - 937f912c-7bcb-49bc-9ee5-c2e5115be884
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222909Z:da64b2aa-63f2-45f1-8083-ac0e665f77b8
+      - WESTCENTRALUS:20171207T214915Z:937f912c-7bcb-49bc-9ee5-c2e5115be884
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:09 GMT
+      - Thu, 07 Dec 2017 21:49:15 GMT
       Content-Length:
-      - '559'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:10 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3637,7 +3246,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3654,123 +3263,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 48ffeada-b3ab-446b-b3fe-fc286fa40f65
+      - b863e24c-9f83-42b7-a74c-b9cda0cb686a
       X-Ms-Correlation-Request-Id:
-      - 48ffeada-b3ab-446b-b3fe-fc286fa40f65
+      - b863e24c-9f83-42b7-a74c-b9cda0cb686a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222910Z:48ffeada-b3ab-446b-b3fe-fc286fa40f65
+      - WESTCENTRALUS:20171207T214916Z:b863e24c-9f83-42b7-a74c-b9cda0cb686a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:09 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b0ee29cc-1938-4ec4-bb27-0fa1c14ec773
-      X-Ms-Correlation-Request-Id:
-      - b0ee29cc-1938-4ec4-bb27-0fa1c14ec773
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222911Z:b0ee29cc-1938-4ec4-bb27-0fa1c14ec773
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:11 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b123acde-aa83-4d4d-b32d-d2e417afe707
-      X-Ms-Correlation-Request-Id:
-      - b123acde-aa83-4d4d-b32d-d2e417afe707
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222911Z:b123acde-aa83-4d4d-b32d-d2e417afe707
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:10 GMT
+      - Thu, 07 Dec 2017 21:49:16 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:12 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3784,7 +3295,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3801,25 +3312,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7ea23edc-bf85-4305-b3a8-245eebe93629
+      - 8ae786de-659c-40aa-81cd-217f6f7e40da
       X-Ms-Correlation-Request-Id:
-      - 7ea23edc-bf85-4305-b3a8-245eebe93629
+      - 8ae786de-659c-40aa-81cd-217f6f7e40da
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222912Z:7ea23edc-bf85-4305-b3a8-245eebe93629
+      - WESTCENTRALUS:20171207T214916Z:8ae786de-659c-40aa-81cd-217f6f7e40da
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:12 GMT
+      - Thu, 07 Dec 2017 21:49:16 GMT
       Content-Length:
-      - '553'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:12 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3833,7 +3344,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3850,123 +3361,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6ab8b0ba-f26f-4888-9d11-e97491a12b51
+      - 62facd69-d247-4291-bdfc-aba31757664f
       X-Ms-Correlation-Request-Id:
-      - 6ab8b0ba-f26f-4888-9d11-e97491a12b51
+      - 62facd69-d247-4291-bdfc-aba31757664f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222913Z:6ab8b0ba-f26f-4888-9d11-e97491a12b51
+      - WESTCENTRALUS:20171207T214917Z:62facd69-d247-4291-bdfc-aba31757664f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:12 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - abb4d6da-cc7e-4009-b5d9-cfcf61b821ff
-      X-Ms-Correlation-Request-Id:
-      - abb4d6da-cc7e-4009-b5d9-cfcf61b821ff
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222913Z:abb4d6da-cc7e-4009-b5d9-cfcf61b821ff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:13 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 506cfde7-189e-4d8d-9276-cc7cf28df36e
-      X-Ms-Correlation-Request-Id:
-      - 506cfde7-189e-4d8d-9276-cc7cf28df36e
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222914Z:506cfde7-189e-4d8d-9276-cc7cf28df36e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:13 GMT
+      - Thu, 07 Dec 2017 21:49:16 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:14 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3980,7 +3393,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -3997,25 +3410,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 96c07bde-911c-46a3-9325-49881a351b51
+      - ec6ee663-58fc-4cf1-a5a7-4798388c3ac7
       X-Ms-Correlation-Request-Id:
-      - 96c07bde-911c-46a3-9325-49881a351b51
+      - ec6ee663-58fc-4cf1-a5a7-4798388c3ac7
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222915Z:96c07bde-911c-46a3-9325-49881a351b51
+      - WESTCENTRALUS:20171207T214917Z:ec6ee663-58fc-4cf1-a5a7-4798388c3ac7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:14 GMT
+      - Thu, 07 Dec 2017 21:49:16 GMT
       Content-Length:
-      - '554'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:15 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4029,7 +3442,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -4046,123 +3459,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0744b38e-3b5b-400f-8774-5a4ea6f4d8ea
+      - 1494e353-e60a-4003-9f0f-e08aa9b52c12
       X-Ms-Correlation-Request-Id:
-      - 0744b38e-3b5b-400f-8774-5a4ea6f4d8ea
+      - 1494e353-e60a-4003-9f0f-e08aa9b52c12
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222915Z:0744b38e-3b5b-400f-8774-5a4ea6f4d8ea
+      - WESTCENTRALUS:20171207T214918Z:1494e353-e60a-4003-9f0f-e08aa9b52c12
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:14 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 31383049-550f-4c03-92b5-14e841933728
-      X-Ms-Correlation-Request-Id:
-      - 31383049-550f-4c03-92b5-14e841933728
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222916Z:31383049-550f-4c03-92b5-14e841933728
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:15 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:16 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ff25ba19-2c0b-4bda-ab72-fbcea2886d7d
-      X-Ms-Correlation-Request-Id:
-      - ff25ba19-2c0b-4bda-ab72-fbcea2886d7d
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222917Z:ff25ba19-2c0b-4bda-ab72-fbcea2886d7d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:16 GMT
+      - Thu, 07 Dec 2017 21:49:17 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:17 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4176,7 +3491,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -4193,25 +3508,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1fc2ff50-8415-441b-96a8-edcb5f97e471
+      - 9d03343b-a839-4387-87a8-68676be93e61
       X-Ms-Correlation-Request-Id:
-      - 1fc2ff50-8415-441b-96a8-edcb5f97e471
+      - 9d03343b-a839-4387-87a8-68676be93e61
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222917Z:1fc2ff50-8415-441b-96a8-edcb5f97e471
+      - WESTCENTRALUS:20171207T214918Z:9d03343b-a839-4387-87a8-68676be93e61
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:17 GMT
+      - Thu, 07 Dec 2017 21:49:17 GMT
       Content-Length:
-      - '548'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:17 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4225,7 +3540,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -4242,123 +3557,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7f2a5ccb-6f7d-49d7-aa13-0892daa6ee5f
+      - 22ac00eb-d969-4889-a8a9-0ff4b36ed574
       X-Ms-Correlation-Request-Id:
-      - 7f2a5ccb-6f7d-49d7-aa13-0892daa6ee5f
+      - 22ac00eb-d969-4889-a8a9-0ff4b36ed574
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222918Z:7f2a5ccb-6f7d-49d7-aa13-0892daa6ee5f
+      - WESTCENTRALUS:20171207T214918Z:22ac00eb-d969-4889-a8a9-0ff4b36ed574
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:18 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:18 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5214ecfe-fb2e-457e-85e3-c900372914cb
-      X-Ms-Correlation-Request-Id:
-      - 5214ecfe-fb2e-457e-85e3-c900372914cb
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222919Z:5214ecfe-fb2e-457e-85e3-c900372914cb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:18 GMT
-      Content-Length:
-      - '547'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:19 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - cf4ae4d0-8545-4b5b-9e70-682ac0eaac1e
-      X-Ms-Correlation-Request-Id:
-      - cf4ae4d0-8545-4b5b-9e70-682ac0eaac1e
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222919Z:cf4ae4d0-8545-4b5b-9e70-682ac0eaac1e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:19 GMT
+      - Thu, 07 Dec 2017 21:49:17 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:20 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:19 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4372,7 +3589,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -4389,25 +3606,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 651bcae6-1989-4d19-9295-e19e090e766a
+      - 4ab0bb3c-cd76-4bb1-ac01-d17592111a5c
       X-Ms-Correlation-Request-Id:
-      - 651bcae6-1989-4d19-9295-e19e090e766a
+      - 4ab0bb3c-cd76-4bb1-ac01-d17592111a5c
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222920Z:651bcae6-1989-4d19-9295-e19e090e766a
+      - WESTCENTRALUS:20171207T214919Z:4ab0bb3c-cd76-4bb1-ac01-d17592111a5c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:20 GMT
+      - Thu, 07 Dec 2017 21:49:18 GMT
       Content-Length:
-      - '554'
+      - '575'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:20 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:19 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4421,7 +3638,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -4438,123 +3655,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b562e1fe-f72b-4a96-a7fb-4a1e6b6c9901
+      - 90b5a319-7697-49e9-9b18-786732b4e76e
       X-Ms-Correlation-Request-Id:
-      - b562e1fe-f72b-4a96-a7fb-4a1e6b6c9901
+      - 90b5a319-7697-49e9-9b18-786732b4e76e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222921Z:b562e1fe-f72b-4a96-a7fb-4a1e6b6c9901
+      - WESTCENTRALUS:20171207T214919Z:90b5a319-7697-49e9-9b18-786732b4e76e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:20 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - d821508b-ec69-48db-a5aa-4c0e4fe6f23a
-      X-Ms-Correlation-Request-Id:
-      - d821508b-ec69-48db-a5aa-4c0e4fe6f23a
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222921Z:d821508b-ec69-48db-a5aa-4c0e4fe6f23a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:20 GMT
-      Content-Length:
-      - '548'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 03c46904-f7b5-4b90-904e-4a2f4d5c44c1
-      X-Ms-Correlation-Request-Id:
-      - 03c46904-f7b5-4b90-904e-4a2f4d5c44c1
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222922Z:03c46904-f7b5-4b90-904e-4a2f4d5c44c1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:21 GMT
+      - Thu, 07 Dec 2017 21:49:19 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:22 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:19 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4568,7 +3687,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -4585,25 +3704,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0361e3f4-bccf-424e-9dc3-f6d4cb937a59
+      - 3504b6f0-fd89-425d-b4a4-d08b1f08662d
       X-Ms-Correlation-Request-Id:
-      - 0361e3f4-bccf-424e-9dc3-f6d4cb937a59
+      - 3504b6f0-fd89-425d-b4a4-d08b1f08662d
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222923Z:0361e3f4-bccf-424e-9dc3-f6d4cb937a59
+      - WESTCENTRALUS:20171207T214920Z:3504b6f0-fd89-425d-b4a4-d08b1f08662d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:22 GMT
+      - Thu, 07 Dec 2017 21:49:19 GMT
       Content-Length:
-      - '553'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:23 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4617,7 +3736,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
   response:
     status:
       code: 200
@@ -4634,118 +3753,1000 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e0e65903-0b12-4ab4-9fc7-3dd76686f68d
+      - fcdfc418-a036-421a-8ad9-88e3f347cf85
       X-Ms-Correlation-Request-Id:
-      - e0e65903-0b12-4ab4-9fc7-3dd76686f68d
+      - fcdfc418-a036-421a-8ad9-88e3f347cf85
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222924Z:e0e65903-0b12-4ab4-9fc7-3dd76686f68d
+      - WESTCENTRALUS:20171207T214920Z:fcdfc418-a036-421a-8ad9-88e3f347cf85
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:23 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - '08eca2b2-ca4c-41ca-94e6-61e09abf2ff6'
-      X-Ms-Correlation-Request-Id:
-      - '08eca2b2-ca4c-41ca-94e6-61e09abf2ff6'
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222924Z:08eca2b2-ca4c-41ca-94e6-61e09abf2ff6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:24 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwMjcsIm5iZiI6MTUxMjE2NzAyNywiZXhwIjoxNTEyMTcwOTI3LCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUtmTkhfRm9va1NRcVlEVHd4WXFBQSIsInZlciI6IjEuMCJ9.KM6lV6Vxy9bcdgp55oUVDL6Wh7qLlSi5VMYLHsXqU0_02nMbjFOE3nitjOi_x_JPdiJexdoT9nqTNOYqtZlDF5vsQC8ihVxXFCk0Lz82iMg-MIXdzSynYoQlhRCaNR-cO1njJ_aK1dBmFrUc_OSUDOH91P2CiI2WhUG92eqxzNNgfmyR1Mfg8-yeOTRz-_haD9lXqK0Klx7Sphw_H5GIHxS-YDr8XCebdN_kp3f-j6bynUMPjXgVEcqFcamBTtmzmqWY-cRrgjNyLJPW0UTtI3AJIVf4aMY9dxxVrsKuW2sHO9B8DRiA6QyiPFNpHHqwvYlLyBxSXBRVXKWn5e_2lg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fedadc97-143f-44de-9b6a-4cc24eefdf03
-      X-Ms-Correlation-Request-Id:
-      - fedadc97-143f-44de-9b6a-4cc24eefdf03
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222925Z:fedadc97-143f-44de-9b6a-4cc24eefdf03
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:24 GMT
+      - Thu, 07 Dec 2017 21:49:19 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:25 GMT
+  recorded_at: Thu, 07 Dec 2017 21:49:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f6070434-f8b8-474f-aa0c-c1ae7d21215b
+      X-Ms-Correlation-Request-Id:
+      - f6070434-f8b8-474f-aa0c-c1ae7d21215b
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214920Z:f6070434-f8b8-474f-aa0c-c1ae7d21215b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:20 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7de0b640-1ba8-4a4b-8751-07779c5610b0
+      X-Ms-Correlation-Request-Id:
+      - 7de0b640-1ba8-4a4b-8751-07779c5610b0
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214921Z:7de0b640-1ba8-4a4b-8751-07779c5610b0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:20 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 669c4b9f-ff27-46cb-9dd4-bcfbad70961e
+      X-Ms-Correlation-Request-Id:
+      - 669c4b9f-ff27-46cb-9dd4-bcfbad70961e
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214921Z:669c4b9f-ff27-46cb-9dd4-bcfbad70961e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:20 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ad610ef9-e7c2-4b40-a952-1162753fb3d9
+      X-Ms-Correlation-Request-Id:
+      - ad610ef9-e7c2-4b40-a952-1162753fb3d9
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214922Z:ad610ef9-e7c2-4b40-a952-1162753fb3d9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:21 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 78bd3010-acd5-44db-8aa4-766789226699
+      X-Ms-Correlation-Request-Id:
+      - 78bd3010-acd5-44db-8aa4-766789226699
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214922Z:78bd3010-acd5-44db-8aa4-766789226699
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:22 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b936e551-ac60-47b2-ade7-d3e7eea113ac
+      X-Ms-Correlation-Request-Id:
+      - b936e551-ac60-47b2-ade7-d3e7eea113ac
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214923Z:b936e551-ac60-47b2-ade7-d3e7eea113ac
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:22 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f1f121dd-99a2-45d7-a3cd-fc7e558f2ee6
+      X-Ms-Correlation-Request-Id:
+      - f1f121dd-99a2-45d7-a3cd-fc7e558f2ee6
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214923Z:f1f121dd-99a2-45d7-a3cd-fc7e558f2ee6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:23 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c53939d1-3597-428d-bdae-1b623f5715d4
+      X-Ms-Correlation-Request-Id:
+      - c53939d1-3597-428d-bdae-1b623f5715d4
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214923Z:c53939d1-3597-428d-bdae-1b623f5715d4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:23 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8da57ded-e27f-414b-a867-cd3692ab252e
+      X-Ms-Correlation-Request-Id:
+      - 8da57ded-e27f-414b-a867-cd3692ab252e
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214924Z:8da57ded-e27f-414b-a867-cd3692ab252e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:23 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 057a3df5-99c5-4553-acf5-46fd6d2ac55a
+      X-Ms-Correlation-Request-Id:
+      - 057a3df5-99c5-4553-acf5-46fd6d2ac55a
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214924Z:057a3df5-99c5-4553-acf5-46fd6d2ac55a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:24 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:24 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0d2d77bf-b2da-4a51-9da3-19caff752d15
+      X-Ms-Correlation-Request-Id:
+      - 0d2d77bf-b2da-4a51-9da3-19caff752d15
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214925Z:0d2d77bf-b2da-4a51-9da3-19caff752d15
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:24 GMT
+      Content-Length:
+      - '563'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c6aa5ae8-ca23-4eac-b4ee-127d5cfd978a
+      X-Ms-Correlation-Request-Id:
+      - c6aa5ae8-ca23-4eac-b4ee-127d5cfd978a
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214925Z:c6aa5ae8-ca23-4eac-b4ee-127d5cfd978a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:25 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:25 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6c8b4aa7-2826-454d-8ed9-0c3e2a187588
+      X-Ms-Correlation-Request-Id:
+      - 6c8b4aa7-2826-454d-8ed9-0c3e2a187588
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214926Z:6c8b4aa7-2826-454d-8ed9-0c3e2a187588
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:26 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - cbea113b-2478-4e10-9bac-aff890a4ed5b
+      X-Ms-Correlation-Request-Id:
+      - cbea113b-2478-4e10-9bac-aff890a4ed5b
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214926Z:cbea113b-2478-4e10-9bac-aff890a4ed5b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:26 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - '08fffbc2-d656-4380-8760-2fd63952e080'
+      X-Ms-Correlation-Request-Id:
+      - '08fffbc2-d656-4380-8760-2fd63952e080'
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214926Z:08fffbc2-d656-4380-8760-2fd63952e080
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:25 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 923817f7-d2f4-449d-a2ed-6f971e16eb0c
+      X-Ms-Correlation-Request-Id:
+      - 923817f7-d2f4-449d-a2ed-6f971e16eb0c
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214927Z:923817f7-d2f4-449d-a2ed-6f971e16eb0c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:27 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 78429881-2d16-4469-a6f1-92498b087386
+      X-Ms-Correlation-Request-Id:
+      - 78429881-2d16-4469-a6f1-92498b087386
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214927Z:78429881-2d16-4469-a6f1-92498b087386
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:27 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 197d5048-aab8-4a94-b123-1d5c8d13f2ee
+      X-Ms-Correlation-Request-Id:
+      - 197d5048-aab8-4a94-b123-1d5c8d13f2ee
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214928Z:197d5048-aab8-4a94-b123-1d5c8d13f2ee
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:28 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - fbee848b-88de-4e21-850c-a69543ea401a
+      X-Ms-Correlation-Request-Id:
+      - fbee848b-88de-4e21-850c-a69543ea401a
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214928Z:fbee848b-88de-4e21-850c-a69543ea401a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:27 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwNDUsIm5iZiI6MTUxMjY4MzA0NSwiZXhwIjoxNTEyNjg2OTQ1LCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidHhuakNIZzh3a2lIZHg4Q1hTWU1BQSIsInZlciI6IjEuMCJ9.IfXY5esQfpdrb_cJWxrkFo6WaQ4Wp8kD7Z7ZgjkZKKLQJwWeUvpVyqzQXK-ZySXbzWcxqA8UGhyVx6-3TcLQgOW3f8KS9MDSu2QBwdYsanbeFIMTg5w68jn847rah_F_3Xi4a_le7NfNH-iaD9nHR-1O14_s15nYoKvqYEDlTM1np2_dqMadNg2hJcf2038mCNVAmzGuhZcbAVvVvD9rpso5Dtz6CbHP-NDy2R-dYBWCiE9xe1Ud6zk0MpfKC8rzjPHZwb2YQwoQmI8QqZwm7sTIJCdRzwUowDjBMA1S7ozwIHAdGIh2saDTxcZdiMsDUWIZQCFOp0qHYBIEBXpulA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9ff33099-d146-445c-859c-2b651f6d9b54
+      X-Ms-Correlation-Request-Id:
+      - 9ff33099-d146-445c-859c-2b651f6d9b54
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214929Z:9ff33099-d146-445c-859c-2b651f6d9b54
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:28 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_and_backup_name.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_and_backup_name.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - ff104a60-ea6c-474b-baaa-91229ca22f00
+      - b5711595-8d70-4eb1-a5f3-87b2b09d0c00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz9dUlB2o45MfVT7YxV742RXch39_PPEXnFVPkKOM1YI4RoiNAYSLDHWhgoBDcgpxgx9mhPv2gtXQRQiCStK_zJ9yXgKeb1e43WHz_CI_igOgEtn3yfSf6oHHDo3YVsTws_TL36Fa7SdUzNpqGB1-eV0QPyGT1IyTkzYuycPhdSHYgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHze37ChIcVW-42sKHHjGwd04pM7I7W86bakywT31IFcfeGXa69UY9kZr8GuzwfQr34u0bhAEwMN7jsbChKi5h8OEVM8yOg32ni9wy4IqwNVZHBb3SgpSbeasqfw_9868WFp1vhzxKWKfc3jFHubFCaS98Uw9AtbLdEHdHUc2sv4AMgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 01 Dec 2017 22:29:24 GMT
+      - Thu, 07 Dec 2017 21:48:15 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1512170966","not_before":"1512167066","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1512686895","not_before":"1512682995","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:26 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -91,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14998'
       X-Ms-Request-Id:
-      - ef1d8bee-8cb5-4fe8-aa7f-89fb1fec28f0
+      - ae4a8284-c3de-4a6d-a9ed-a47b72b30301
       X-Ms-Correlation-Request-Id:
-      - ef1d8bee-8cb5-4fe8-aa7f-89fb1fec28f0
+      - ae4a8284-c3de-4a6d-a9ed-a47b72b30301
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222926Z:ef1d8bee-8cb5-4fe8-aa7f-89fb1fec28f0
+      - WESTCENTRALUS:20171207T214816Z:ae4a8284-c3de-4a6d-a9ed-a47b72b30301
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:26 GMT
+      - Thu, 07 Dec 2017 21:48:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:26 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -124,7 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -141,19 +141,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14926'
+      - '14977'
       X-Ms-Request-Id:
-      - f6871032-cf3d-4fe3-a6c2-aec1ea8879a6
+      - 787a624e-d9d6-44eb-a8f8-76bb9e64b1ca
       X-Ms-Correlation-Request-Id:
-      - f6871032-cf3d-4fe3-a6c2-aec1ea8879a6
+      - 787a624e-d9d6-44eb-a8f8-76bb9e64b1ca
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222927Z:f6871032-cf3d-4fe3-a6c2-aec1ea8879a6
+      - WESTCENTRALUS:20171207T214817Z:787a624e-d9d6-44eb-a8f8-76bb9e64b1ca
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:27 GMT
+      - Thu, 07 Dec 2017 21:48:16 GMT
       Content-Length:
-      - '278554'
+      - '279208'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -260,7 +260,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -491,7 +491,7 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
-        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
         US","UK West","West India","Australia East","Brazil South","Canada East","East
@@ -614,92 +614,92 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","North
         Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
         South","Japan East","Japan West","North Europe","West Europe","Central India","South
@@ -816,7 +816,7 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
@@ -1459,7 +1459,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1606,7 +1606,8 @@ http_interactions:
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
@@ -1873,23 +1874,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1938,8 +1939,8 @@ http_interactions:
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
         Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
-        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"operations","locations":["Central
-        US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
@@ -2017,8 +2018,8 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -2030,18 +2031,18 @@ http_interactions:
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
@@ -2122,7 +2123,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:28 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:17 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/locations?api-version=2015-01-01
@@ -2139,7 +2140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2156,17 +2157,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14938'
+      - '14976'
       X-Ms-Request-Id:
-      - 40c6d581-0765-4167-957d-0e466c96db9c
+      - 2d665ccc-6fc1-4b68-8756-2ebf9a7e514c
       X-Ms-Correlation-Request-Id:
-      - 40c6d581-0765-4167-957d-0e466c96db9c
+      - 2d665ccc-6fc1-4b68-8756-2ebf9a7e514c
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222928Z:40c6d581-0765-4167-957d-0e466c96db9c
+      - WESTCENTRALUS:20171207T214817Z:2d665ccc-6fc1-4b68-8756-2ebf9a7e514c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:27 GMT
+      - Thu, 07 Dec 2017 21:48:16 GMT
       Content-Length:
       - '4523'
     body:
@@ -2199,10 +2200,10 @@ http_interactions:
         Central","longitude":"126.9780","latitude":"37.5665"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/locations/koreasouth","name":"koreasouth","displayName":"Korea
         South","longitude":"129.0756","latitude":"35.1796"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:28 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2216,7 +2217,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2233,25 +2234,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 79acfac5-a2ec-491d-9742-2beb4bb6ad91
+      - 81499807-ddb2-41c7-bd49-a38dc45997da
       X-Ms-Correlation-Request-Id:
-      - 79acfac5-a2ec-491d-9742-2beb4bb6ad91
+      - 81499807-ddb2-41c7-bd49-a38dc45997da
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222929Z:79acfac5-a2ec-491d-9742-2beb4bb6ad91
+      - WESTCENTRALUS:20171207T214818Z:81499807-ddb2-41c7-bd49-a38dc45997da
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:28 GMT
+      - Thu, 07 Dec 2017 21:48:17 GMT
       Content-Length:
-      - '549'
+      - '565'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:29 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2265,7 +2266,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2282,123 +2283,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4fe50260-7d87-4285-9cd1-3f5f8018c902
+      - 233dcb50-a3c1-42bb-ada5-51ff12152685
       X-Ms-Correlation-Request-Id:
-      - 4fe50260-7d87-4285-9cd1-3f5f8018c902
+      - 233dcb50-a3c1-42bb-ada5-51ff12152685
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222930Z:4fe50260-7d87-4285-9cd1-3f5f8018c902
+      - WESTCENTRALUS:20171207T214818Z:233dcb50-a3c1-42bb-ada5-51ff12152685
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:30 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5fa2c936-98b6-4cc3-8f3f-ec2d94d2bce6
-      X-Ms-Correlation-Request-Id:
-      - 5fa2c936-98b6-4cc3-8f3f-ec2d94d2bce6
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222931Z:5fa2c936-98b6-4cc3-8f3f-ec2d94d2bce6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:31 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4dea352d-00c9-4fd6-b81a-b6c3ee1cceab
-      X-Ms-Correlation-Request-Id:
-      - 4dea352d-00c9-4fd6-b81a-b6c3ee1cceab
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222932Z:4dea352d-00c9-4fd6-b81a-b6c3ee1cceab
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:32 GMT
+      - Thu, 07 Dec 2017 21:48:18 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:32 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2412,7 +2315,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2429,25 +2332,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f91e84f1-e580-462a-ae48-7a8e5627da8d
+      - a04acad9-a937-401b-9e87-dea24ee73cd8
       X-Ms-Correlation-Request-Id:
-      - f91e84f1-e580-462a-ae48-7a8e5627da8d
+      - a04acad9-a937-401b-9e87-dea24ee73cd8
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222933Z:f91e84f1-e580-462a-ae48-7a8e5627da8d
+      - WESTCENTRALUS:20171207T214819Z:a04acad9-a937-401b-9e87-dea24ee73cd8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:33 GMT
+      - Thu, 07 Dec 2017 21:48:18 GMT
       Content-Length:
-      - '550'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:33 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:19 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2461,7 +2364,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2478,25 +2381,123 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e5537c05-4517-40e2-8d3b-ae1a5bf2706c
+      - '0831ddc7-647d-453c-aba3-54560379ca1d'
       X-Ms-Correlation-Request-Id:
-      - e5537c05-4517-40e2-8d3b-ae1a5bf2706c
+      - '0831ddc7-647d-453c-aba3-54560379ca1d'
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222934Z:e5537c05-4517-40e2-8d3b-ae1a5bf2706c
+      - WESTCENTRALUS:20171207T214819Z:0831ddc7-647d-453c-aba3-54560379ca1d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:33 GMT
+      - Thu, 07 Dec 2017 21:48:18 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 716d15a1-fbd6-4956-bfef-63db2af76d7f
+      X-Ms-Correlation-Request-Id:
+      - 716d15a1-fbd6-4956-bfef-63db2af76d7f
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214819Z:716d15a1-fbd6-4956-bfef-63db2af76d7f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:19 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 64fbf73f-2e8b-4483-9226-54fe03e45fbe
+      X-Ms-Correlation-Request-Id:
+      - 64fbf73f-2e8b-4483-9226-54fe03e45fbe
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214820Z:64fbf73f-2e8b-4483-9226-54fe03e45fbe
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:20 GMT
       Content-Length:
       - '1104'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2","name":"jf-metrics-2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3","name":"jf-metrics-3","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1","name":"miqazure-oraclelinux1","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2","name":"miqazure-oraclelinux2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"false"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:34 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2510,7 +2511,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2527,25 +2528,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - df1e7556-3493-4079-88a3-494d6d2d2771
+      - 97d8e78a-3ffb-4983-9eb8-cb3d6aeca515
       X-Ms-Correlation-Request-Id:
-      - df1e7556-3493-4079-88a3-494d6d2d2771
+      - 97d8e78a-3ffb-4983-9eb8-cb3d6aeca515
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222935Z:df1e7556-3493-4079-88a3-494d6d2d2771
+      - WESTCENTRALUS:20171207T214820Z:97d8e78a-3ffb-4983-9eb8-cb3d6aeca515
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:35 GMT
+      - Thu, 07 Dec 2017 21:48:19 GMT
       Content-Length:
-      - '547'
+      - '563'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:35 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2559,7 +2560,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2576,25 +2577,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b4f36b3b-7575-4a5d-ad51-360bd66e3aae
+      - 8c79bd8d-74bc-42a4-82e3-538a8d5b306e
       X-Ms-Correlation-Request-Id:
-      - b4f36b3b-7575-4a5d-ad51-360bd66e3aae
+      - 8c79bd8d-74bc-42a4-82e3-538a8d5b306e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222936Z:b4f36b3b-7575-4a5d-ad51-360bd66e3aae
+      - WESTCENTRALUS:20171207T214821Z:8c79bd8d-74bc-42a4-82e3-538a8d5b306e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:36 GMT
+      - Thu, 07 Dec 2017 21:48:20 GMT
       Content-Length:
       - '3378'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","name":"miq-test-rhel1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","name":"miq-test-ubuntu1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","name":"miq-test-win12","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","name":"miq-test-winimg","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","name":"miqazure-centos1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","name":"rspec-lb-a","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","name":"rspec-lb-b","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","name":"spec0deply1vm0","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","name":"spec0deply1vm1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2","name":"miqmismatch2","type":"Microsoft.Compute/virtualMachines","location":"eastus","plan":{"name":"rhel74","product":"rhel-byol-preview","publisher":"redhat"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/dbergerprov1","name":"dbergerprov1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","name":"miqazure-linux-managed","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1","name":"miqmismatch1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:36 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2608,7 +2609,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2625,25 +2626,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b9046cde-bbfc-48b2-ba5e-2380f127aad6
+      - 114e3e20-9b01-4002-8c63-589629407ef2
       X-Ms-Correlation-Request-Id:
-      - b9046cde-bbfc-48b2-ba5e-2380f127aad6
+      - 114e3e20-9b01-4002-8c63-589629407ef2
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222937Z:b9046cde-bbfc-48b2-ba5e-2380f127aad6
+      - WESTCENTRALUS:20171207T214821Z:114e3e20-9b01-4002-8c63-589629407ef2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:37 GMT
+      - Thu, 07 Dec 2017 21:48:21 GMT
       Content-Length:
-      - '548'
+      - '564'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:37 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2657,7 +2658,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2674,25 +2675,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d9804946-45c4-463b-8ee1-c92a84e1f214
+      - 5faf265c-0b5b-462c-8f35-eaa902ff8ef7
       X-Ms-Correlation-Request-Id:
-      - d9804946-45c4-463b-8ee1-c92a84e1f214
+      - 5faf265c-0b5b-462c-8f35-eaa902ff8ef7
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222938Z:d9804946-45c4-463b-8ee1-c92a84e1f214
+      - WESTCENTRALUS:20171207T214821Z:5faf265c-0b5b-462c-8f35-eaa902ff8ef7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:38 GMT
+      - Thu, 07 Dec 2017 21:48:21 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:38 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2706,7 +2707,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2723,25 +2724,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3de462ee-eff4-450e-a91c-b28854201105
+      - 5484500b-4004-47f3-9ef0-3ad79d3706ff
       X-Ms-Correlation-Request-Id:
-      - 3de462ee-eff4-450e-a91c-b28854201105
+      - 5484500b-4004-47f3-9ef0-3ad79d3706ff
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222939Z:3de462ee-eff4-450e-a91c-b28854201105
+      - WESTCENTRALUS:20171207T214822Z:5484500b-4004-47f3-9ef0-3ad79d3706ff
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:39 GMT
+      - Thu, 07 Dec 2017 21:48:22 GMT
       Content-Length:
-      - '547'
+      - '563'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:39 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2755,7 +2756,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2772,25 +2773,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 13e05207-bfea-4b9d-8009-39f3c7a86d18
+      - debb38fe-4a06-4ef8-bf0c-94fc407b24d4
       X-Ms-Correlation-Request-Id:
-      - 13e05207-bfea-4b9d-8009-39f3c7a86d18
+      - debb38fe-4a06-4ef8-bf0c-94fc407b24d4
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222940Z:13e05207-bfea-4b9d-8009-39f3c7a86d18
+      - WESTCENTRALUS:20171207T214822Z:debb38fe-4a06-4ef8-bf0c-94fc407b24d4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:40 GMT
+      - Thu, 07 Dec 2017 21:48:21 GMT
       Content-Length:
       - '280'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1","name":"miqazure-coreos1","type":"Microsoft.Compute/virtualMachines","location":"westus","tags":{"Shutdown":"true"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:40 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2804,7 +2805,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2821,25 +2822,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 91f7e359-551c-4e24-b993-14be0e3d2529
+      - 20093ee5-4c6b-4769-a114-527ab8c341b5
       X-Ms-Correlation-Request-Id:
-      - 91f7e359-551c-4e24-b993-14be0e3d2529
+      - 20093ee5-4c6b-4769-a114-527ab8c341b5
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222941Z:91f7e359-551c-4e24-b993-14be0e3d2529
+      - WESTCENTRALUS:20171207T214823Z:20093ee5-4c6b-4769-a114-527ab8c341b5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:41 GMT
+      - Thu, 07 Dec 2017 21:48:22 GMT
       Content-Length:
-      - '555'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:41 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2853,7 +2854,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -2870,123 +2871,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b78e1e72-d04e-491a-891f-2d6f543e5b38
+      - 2e04d223-b78e-4d49-9c29-182f7bbba9b9
       X-Ms-Correlation-Request-Id:
-      - b78e1e72-d04e-491a-891f-2d6f543e5b38
+      - 2e04d223-b78e-4d49-9c29-182f7bbba9b9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222941Z:b78e1e72-d04e-491a-891f-2d6f543e5b38
+      - WESTCENTRALUS:20171207T214823Z:2e04d223-b78e-4d49-9c29-182f7bbba9b9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:41 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - be4cf96a-f28b-4866-b3fb-6b6ad376af25
-      X-Ms-Correlation-Request-Id:
-      - be4cf96a-f28b-4866-b3fb-6b6ad376af25
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222942Z:be4cf96a-f28b-4866-b3fb-6b6ad376af25
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:42 GMT
-      Content-Length:
-      - '555'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd1e09a8-5925-4a76-bd39-cc65bbe5f607
-      X-Ms-Correlation-Request-Id:
-      - bd1e09a8-5925-4a76-bd39-cc65bbe5f607
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222943Z:bd1e09a8-5925-4a76-bd39-cc65bbe5f607
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:43 GMT
+      - Thu, 07 Dec 2017 21:48:23 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:43 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3000,7 +2903,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3017,25 +2920,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2f9b9a4a-f038-4d81-9bc2-38e71f1ae402
+      - f6c8b453-6662-49e6-a103-bdfdc156919a
       X-Ms-Correlation-Request-Id:
-      - 2f9b9a4a-f038-4d81-9bc2-38e71f1ae402
+      - f6c8b453-6662-49e6-a103-bdfdc156919a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222944Z:2f9b9a4a-f038-4d81-9bc2-38e71f1ae402
+      - WESTCENTRALUS:20171207T214823Z:f6c8b453-6662-49e6-a103-bdfdc156919a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:44 GMT
+      - Thu, 07 Dec 2017 21:48:23 GMT
       Content-Length:
-      - '552'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:45 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3049,7 +2952,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3066,123 +2969,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 643d69de-a62c-4fd0-a8e4-23eb88c174b1
+      - b89e2e43-3ce8-4755-b3e3-11efe3bb9799
       X-Ms-Correlation-Request-Id:
-      - 643d69de-a62c-4fd0-a8e4-23eb88c174b1
+      - b89e2e43-3ce8-4755-b3e3-11efe3bb9799
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222945Z:643d69de-a62c-4fd0-a8e4-23eb88c174b1
+      - WESTCENTRALUS:20171207T214824Z:b89e2e43-3ce8-4755-b3e3-11efe3bb9799
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:45 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - df2098d5-c072-47f9-8388-d3b9ec7f34ed
-      X-Ms-Correlation-Request-Id:
-      - df2098d5-c072-47f9-8388-d3b9ec7f34ed
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222946Z:df2098d5-c072-47f9-8388-d3b9ec7f34ed
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:46 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ba063fdb-b410-4534-ae02-a5b7d90b6e45
-      X-Ms-Correlation-Request-Id:
-      - ba063fdb-b410-4534-ae02-a5b7d90b6e45
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222947Z:ba063fdb-b410-4534-ae02-a5b7d90b6e45
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:47 GMT
+      - Thu, 07 Dec 2017 21:48:23 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:47 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:24 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3196,7 +3001,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3213,25 +3018,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c7b96097-3b96-4cf8-9956-89e0aa55fc5b
+      - f81413ed-ca4e-4c8e-82b1-b91af4bc5162
       X-Ms-Correlation-Request-Id:
-      - c7b96097-3b96-4cf8-9956-89e0aa55fc5b
+      - f81413ed-ca4e-4c8e-82b1-b91af4bc5162
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222948Z:c7b96097-3b96-4cf8-9956-89e0aa55fc5b
+      - WESTCENTRALUS:20171207T214824Z:f81413ed-ca4e-4c8e-82b1-b91af4bc5162
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:47 GMT
+      - Thu, 07 Dec 2017 21:48:24 GMT
       Content-Length:
-      - '550'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:48 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:24 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3245,7 +3050,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3262,123 +3067,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d50c798c-2218-4660-ab81-36f3c07de4e8
+      - 318de2e0-460c-4b8f-b44b-6a3ddd27ff3e
       X-Ms-Correlation-Request-Id:
-      - d50c798c-2218-4660-ab81-36f3c07de4e8
+      - 318de2e0-460c-4b8f-b44b-6a3ddd27ff3e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222948Z:d50c798c-2218-4660-ab81-36f3c07de4e8
+      - WESTCENTRALUS:20171207T214825Z:318de2e0-460c-4b8f-b44b-6a3ddd27ff3e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:48 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fa0620d3-5997-47a8-8ac2-ac0d678c6ed8
-      X-Ms-Correlation-Request-Id:
-      - fa0620d3-5997-47a8-8ac2-ac0d678c6ed8
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222949Z:fa0620d3-5997-47a8-8ac2-ac0d678c6ed8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:49 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6ad1e19b-890f-4a5a-9244-7f85c5f82ee0
-      X-Ms-Correlation-Request-Id:
-      - 6ad1e19b-890f-4a5a-9244-7f85c5f82ee0
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222950Z:6ad1e19b-890f-4a5a-9244-7f85c5f82ee0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:49 GMT
+      - Thu, 07 Dec 2017 21:48:24 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:50 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:25 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3392,7 +3099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3409,25 +3116,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 819dd71c-504f-472f-80d2-9c716f2c8091
+      - bbf7148f-54e3-4295-b3ab-350e0e676dcf
       X-Ms-Correlation-Request-Id:
-      - 819dd71c-504f-472f-80d2-9c716f2c8091
+      - bbf7148f-54e3-4295-b3ab-350e0e676dcf
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222950Z:819dd71c-504f-472f-80d2-9c716f2c8091
+      - WESTCENTRALUS:20171207T214825Z:bbf7148f-54e3-4295-b3ab-350e0e676dcf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:49 GMT
+      - Thu, 07 Dec 2017 21:48:25 GMT
       Content-Length:
-      - '552'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:51 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:25 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3441,7 +3148,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3458,123 +3165,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 075447fe-3674-47b2-a1ba-7f8f62bc2b0c
+      - 7e7baee0-f005-4f2c-a049-d089304c25ba
       X-Ms-Correlation-Request-Id:
-      - 075447fe-3674-47b2-a1ba-7f8f62bc2b0c
+      - 7e7baee0-f005-4f2c-a049-d089304c25ba
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222951Z:075447fe-3674-47b2-a1ba-7f8f62bc2b0c
+      - WESTCENTRALUS:20171207T214826Z:7e7baee0-f005-4f2c-a049-d089304c25ba
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:50 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 743f020c-3050-43d7-875c-08cb5a972585
-      X-Ms-Correlation-Request-Id:
-      - 743f020c-3050-43d7-875c-08cb5a972585
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222952Z:743f020c-3050-43d7-875c-08cb5a972585
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:52 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - eb118e5a-1c7c-4207-ac84-57048548056b
-      X-Ms-Correlation-Request-Id:
-      - eb118e5a-1c7c-4207-ac84-57048548056b
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222953Z:eb118e5a-1c7c-4207-ac84-57048548056b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:52 GMT
+      - Thu, 07 Dec 2017 21:48:26 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:53 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:26 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3588,7 +3197,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3605,25 +3214,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - daa18d32-5438-45ea-b3d8-eb8a6500073e
+      - b8268225-7158-4fa4-819d-c1cc12932032
       X-Ms-Correlation-Request-Id:
-      - daa18d32-5438-45ea-b3d8-eb8a6500073e
+      - b8268225-7158-4fa4-819d-c1cc12932032
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222954Z:daa18d32-5438-45ea-b3d8-eb8a6500073e
+      - WESTCENTRALUS:20171207T214826Z:b8268225-7158-4fa4-819d-c1cc12932032
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:53 GMT
+      - Thu, 07 Dec 2017 21:48:26 GMT
       Content-Length:
-      - '559'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:54 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:26 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3637,7 +3246,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3654,123 +3263,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - aaaebb69-b0b0-4723-9054-a679f33dab23
+      - 5d3d2253-f323-4ed1-9c8e-9a137247b85b
       X-Ms-Correlation-Request-Id:
-      - aaaebb69-b0b0-4723-9054-a679f33dab23
+      - 5d3d2253-f323-4ed1-9c8e-9a137247b85b
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222955Z:aaaebb69-b0b0-4723-9054-a679f33dab23
+      - WESTCENTRALUS:20171207T214826Z:5d3d2253-f323-4ed1-9c8e-9a137247b85b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:55 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - c32555d4-9a91-42cf-aab4-cd800fe9bdd2
-      X-Ms-Correlation-Request-Id:
-      - c32555d4-9a91-42cf-aab4-cd800fe9bdd2
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222955Z:c32555d4-9a91-42cf-aab4-cd800fe9bdd2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:55 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 622b7c3d-ab10-47ed-b6d3-7d36c6291f06
-      X-Ms-Correlation-Request-Id:
-      - 622b7c3d-ab10-47ed-b6d3-7d36c6291f06
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222956Z:622b7c3d-ab10-47ed-b6d3-7d36c6291f06
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:56 GMT
+      - Thu, 07 Dec 2017 21:48:26 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:56 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:26 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3784,7 +3295,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3801,25 +3312,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 631482db-54a3-4061-91d1-38a5868a72db
+      - 23483323-b66b-4a76-b6ff-0022c3b401ab
       X-Ms-Correlation-Request-Id:
-      - 631482db-54a3-4061-91d1-38a5868a72db
+      - 23483323-b66b-4a76-b6ff-0022c3b401ab
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222957Z:631482db-54a3-4061-91d1-38a5868a72db
+      - WESTCENTRALUS:20171207T214827Z:23483323-b66b-4a76-b6ff-0022c3b401ab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:56 GMT
+      - Thu, 07 Dec 2017 21:48:27 GMT
       Content-Length:
-      - '553'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:57 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3833,7 +3344,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3850,123 +3361,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d903e76d-eaee-494f-9496-b6df9d3c5a60
+      - aff23d62-f77f-44dc-b8eb-802d9623954b
       X-Ms-Correlation-Request-Id:
-      - d903e76d-eaee-494f-9496-b6df9d3c5a60
+      - aff23d62-f77f-44dc-b8eb-802d9623954b
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222958Z:d903e76d-eaee-494f-9496-b6df9d3c5a60
+      - WESTCENTRALUS:20171207T214827Z:aff23d62-f77f-44dc-b8eb-802d9623954b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:57 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - '093d9b66-d97d-4594-a9d5-beb2cc5941c7'
-      X-Ms-Correlation-Request-Id:
-      - '093d9b66-d97d-4594-a9d5-beb2cc5941c7'
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222958Z:093d9b66-d97d-4594-a9d5-beb2cc5941c7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:58 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 843154f9-9cff-4363-9f4e-5c87446f1e44
-      X-Ms-Correlation-Request-Id:
-      - 843154f9-9cff-4363-9f4e-5c87446f1e44
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222959Z:843154f9-9cff-4363-9f4e-5c87446f1e44
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:29:58 GMT
+      - Thu, 07 Dec 2017 21:48:27 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:29:59 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3980,7 +3393,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -3997,25 +3410,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 10bd5da0-c91c-47c5-aecb-13dac45a7c17
+      - ed0d6aa1-924d-45f6-a735-8c9f49eddc67
       X-Ms-Correlation-Request-Id:
-      - 10bd5da0-c91c-47c5-aecb-13dac45a7c17
+      - ed0d6aa1-924d-45f6-a735-8c9f49eddc67
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T222959Z:10bd5da0-c91c-47c5-aecb-13dac45a7c17
+      - WESTCENTRALUS:20171207T214828Z:ed0d6aa1-924d-45f6-a735-8c9f49eddc67
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:29:59 GMT
+      - Thu, 07 Dec 2017 21:48:27 GMT
       Content-Length:
-      - '554'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:00 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4029,7 +3442,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -4046,123 +3459,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 10fedcf8-2bff-408c-8031-6a2b504fbcf3
+      - 0c4f890e-fcf6-4148-998d-987fa663a1a9
       X-Ms-Correlation-Request-Id:
-      - 10fedcf8-2bff-408c-8031-6a2b504fbcf3
+      - 0c4f890e-fcf6-4148-998d-987fa663a1a9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223000Z:10fedcf8-2bff-408c-8031-6a2b504fbcf3
+      - WESTCENTRALUS:20171207T214828Z:0c4f890e-fcf6-4148-998d-987fa663a1a9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:00 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8a1256ed-3400-4c3d-82d3-def709552bb2
-      X-Ms-Correlation-Request-Id:
-      - 8a1256ed-3400-4c3d-82d3-def709552bb2
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223001Z:8a1256ed-3400-4c3d-82d3-def709552bb2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:00 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8701c7e9-ae36-41bc-8cea-5ccc4bf8a98c
-      X-Ms-Correlation-Request-Id:
-      - 8701c7e9-ae36-41bc-8cea-5ccc4bf8a98c
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223001Z:8701c7e9-ae36-41bc-8cea-5ccc4bf8a98c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:01 GMT
+      - Thu, 07 Dec 2017 21:48:28 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:01 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4176,7 +3491,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -4193,25 +3508,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5f585628-3b82-4185-90b9-8bc2a6954dc4
+      - 80d2ff67-4429-41e4-9f51-77360c074c1a
       X-Ms-Correlation-Request-Id:
-      - 5f585628-3b82-4185-90b9-8bc2a6954dc4
+      - 80d2ff67-4429-41e4-9f51-77360c074c1a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223002Z:5f585628-3b82-4185-90b9-8bc2a6954dc4
+      - WESTCENTRALUS:20171207T214828Z:80d2ff67-4429-41e4-9f51-77360c074c1a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:02 GMT
+      - Thu, 07 Dec 2017 21:48:28 GMT
       Content-Length:
-      - '548'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:02 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4225,7 +3540,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -4242,123 +3557,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 98198092-df42-4508-8cac-b776a7b0f8c4
+      - 8b2d1496-0ab0-4bda-8260-9d6b59ff37e7
       X-Ms-Correlation-Request-Id:
-      - 98198092-df42-4508-8cac-b776a7b0f8c4
+      - 8b2d1496-0ab0-4bda-8260-9d6b59ff37e7
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223003Z:98198092-df42-4508-8cac-b776a7b0f8c4
+      - WESTCENTRALUS:20171207T214829Z:8b2d1496-0ab0-4bda-8260-9d6b59ff37e7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:02 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0606fbbb-8637-494b-88ad-b69b5de5c77a
-      X-Ms-Correlation-Request-Id:
-      - 0606fbbb-8637-494b-88ad-b69b5de5c77a
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223004Z:0606fbbb-8637-494b-88ad-b69b5de5c77a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:03 GMT
-      Content-Length:
-      - '547'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:04 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5611835b-b30e-470a-9112-ce7d4d6dc546
-      X-Ms-Correlation-Request-Id:
-      - 5611835b-b30e-470a-9112-ce7d4d6dc546
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223005Z:5611835b-b30e-470a-9112-ce7d4d6dc546
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:05 GMT
+      - Thu, 07 Dec 2017 21:48:29 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:05 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:29 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4372,7 +3589,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -4389,25 +3606,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c2e23e16-64c0-4027-a30b-b97432a97466
+      - 99d21112-43e2-4b97-8156-bc68ee8e7551
       X-Ms-Correlation-Request-Id:
-      - c2e23e16-64c0-4027-a30b-b97432a97466
+      - 99d21112-43e2-4b97-8156-bc68ee8e7551
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223006Z:c2e23e16-64c0-4027-a30b-b97432a97466
+      - WESTCENTRALUS:20171207T214829Z:99d21112-43e2-4b97-8156-bc68ee8e7551
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:05 GMT
+      - Thu, 07 Dec 2017 21:48:29 GMT
       Content-Length:
-      - '554'
+      - '575'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:06 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:29 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4421,7 +3638,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -4438,123 +3655,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f64f261c-f9c2-4c49-9700-e7e150300c57
+      - 6296a9f9-e273-4b94-9ee5-023e694e0018
       X-Ms-Correlation-Request-Id:
-      - f64f261c-f9c2-4c49-9700-e7e150300c57
+      - 6296a9f9-e273-4b94-9ee5-023e694e0018
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223006Z:f64f261c-f9c2-4c49-9700-e7e150300c57
+      - WESTCENTRALUS:20171207T214829Z:6296a9f9-e273-4b94-9ee5-023e694e0018
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:06 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 952b1fef-a672-49e3-a74f-65dd8779b93a
-      X-Ms-Correlation-Request-Id:
-      - 952b1fef-a672-49e3-a74f-65dd8779b93a
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223007Z:952b1fef-a672-49e3-a74f-65dd8779b93a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:07 GMT
-      Content-Length:
-      - '548'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ef37c17e-baeb-4fef-93b3-cc6fd14318d6
-      X-Ms-Correlation-Request-Id:
-      - ef37c17e-baeb-4fef-93b3-cc6fd14318d6
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223008Z:ef37c17e-baeb-4fef-93b3-cc6fd14318d6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:07 GMT
+      - Thu, 07 Dec 2017 21:48:29 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:08 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:29 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4568,7 +3687,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -4585,25 +3704,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2f648fd6-0a20-4cfe-8fda-979bc40eeaab
+      - d06484bc-0e07-47e6-9ebc-c296f3ab7944
       X-Ms-Correlation-Request-Id:
-      - 2f648fd6-0a20-4cfe-8fda-979bc40eeaab
+      - d06484bc-0e07-47e6-9ebc-c296f3ab7944
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223009Z:2f648fd6-0a20-4cfe-8fda-979bc40eeaab
+      - WESTCENTRALUS:20171207T214830Z:d06484bc-0e07-47e6-9ebc-c296f3ab7944
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:08 GMT
+      - Thu, 07 Dec 2017 21:48:30 GMT
       Content-Length:
-      - '553'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:09 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:30 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4617,7 +3736,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
   response:
     status:
       code: 200
@@ -4634,118 +3753,1000 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a87900eb-c08e-4ae6-b144-7db8bb50667d
+      - bac0eec6-a860-4855-9985-0337a27d8de9
       X-Ms-Correlation-Request-Id:
-      - a87900eb-c08e-4ae6-b144-7db8bb50667d
+      - bac0eec6-a860-4855-9985-0337a27d8de9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223009Z:a87900eb-c08e-4ae6-b144-7db8bb50667d
+      - WESTCENTRALUS:20171207T214830Z:bac0eec6-a860-4855-9985-0337a27d8de9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:09 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - '0941f40b-c8af-4e4b-8dc5-2aafb0e1ba57'
-      X-Ms-Correlation-Request-Id:
-      - '0941f40b-c8af-4e4b-8dc5-2aafb0e1ba57'
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223010Z:0941f40b-c8af-4e4b-8dc5-2aafb0e1ba57
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:10 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcwNjYsIm5iZiI6MTUxMjE2NzA2NiwiZXhwIjoxNTEyMTcwOTY2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWUVvUV8yenFTMGU2cXBFaW5LSXZBQSIsInZlciI6IjEuMCJ9.rbG9gCTh9zCH4_Vs_ZASK3CaSOrD-RiY1LmEqip6PyUx7Fbepyuea0znnFKFe_gIfx7Fj0ez_3t9f99jJ_3LgkKwvYKMFl6Vbajre1hq64xfOU5t-D0M13BRwQw5TpDfhQ6APb7P1pZkJwObc8N6FJ2RpZ7woOp-pW-2TFYDzy-Lh4lQzEx9wtHkJGdvY_HHg_gy0tKPyMp-fa3o_AwBczqoigf_go8s80GXQwKpT5UzHmk31uBoQilgaGhoIkAcaRburojNhK-3gbeGzLWRmYMJEJXRt52gQRsT79uMEa5muhh_Ffq7HzmHZR5Fkc4JSafVCWDOZ743Ck0T_LpiQw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7debea61-5bf2-40d9-978a-60526fd25e83
-      X-Ms-Correlation-Request-Id:
-      - 7debea61-5bf2-40d9-978a-60526fd25e83
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223011Z:7debea61-5bf2-40d9-978a-60526fd25e83
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:11 GMT
+      - Thu, 07 Dec 2017 21:48:30 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:11 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b8159795-da7b-4095-a4db-bdd1eaae1a8f
+      X-Ms-Correlation-Request-Id:
+      - b8159795-da7b-4095-a4db-bdd1eaae1a8f
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214831Z:b8159795-da7b-4095-a4db-bdd1eaae1a8f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:30 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4caa59e1-c175-4c8d-9bad-f8f9c31c0171
+      X-Ms-Correlation-Request-Id:
+      - 4caa59e1-c175-4c8d-9bad-f8f9c31c0171
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214831Z:4caa59e1-c175-4c8d-9bad-f8f9c31c0171
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:31 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 37e6c035-7319-42bf-948e-81646fa5d9af
+      X-Ms-Correlation-Request-Id:
+      - 37e6c035-7319-42bf-948e-81646fa5d9af
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214831Z:37e6c035-7319-42bf-948e-81646fa5d9af
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:31 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 821f8274-5029-405a-8da0-0a01b3901e53
+      X-Ms-Correlation-Request-Id:
+      - 821f8274-5029-405a-8da0-0a01b3901e53
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214832Z:821f8274-5029-405a-8da0-0a01b3901e53
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:32 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4952f6c3-9a20-42aa-82fb-223755982a34
+      X-Ms-Correlation-Request-Id:
+      - 4952f6c3-9a20-42aa-82fb-223755982a34
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214832Z:4952f6c3-9a20-42aa-82fb-223755982a34
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:32 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 55642ca4-8f04-43cb-8adb-19c8d7f9d488
+      X-Ms-Correlation-Request-Id:
+      - 55642ca4-8f04-43cb-8adb-19c8d7f9d488
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214833Z:55642ca4-8f04-43cb-8adb-19c8d7f9d488
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:32 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2b11da58-2bd8-4fd3-937e-e51e8c917e0e
+      X-Ms-Correlation-Request-Id:
+      - 2b11da58-2bd8-4fd3-937e-e51e8c917e0e
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214833Z:2b11da58-2bd8-4fd3-937e-e51e8c917e0e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:33 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9e51a720-ef58-4ac9-9d9d-8d258e2c5bff
+      X-Ms-Correlation-Request-Id:
+      - 9e51a720-ef58-4ac9-9d9d-8d258e2c5bff
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214834Z:9e51a720-ef58-4ac9-9d9d-8d258e2c5bff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:33 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - af09bdff-f690-4713-8a08-6b18ab871f9b
+      X-Ms-Correlation-Request-Id:
+      - af09bdff-f690-4713-8a08-6b18ab871f9b
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214834Z:af09bdff-f690-4713-8a08-6b18ab871f9b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:34 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - fea1e3e0-17bd-4396-b196-bcfe8e8ada2c
+      X-Ms-Correlation-Request-Id:
+      - fea1e3e0-17bd-4396-b196-bcfe8e8ada2c
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214834Z:fea1e3e0-17bd-4396-b196-bcfe8e8ada2c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:34 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - fb4f1951-5939-410a-ae55-5f363765ac84
+      X-Ms-Correlation-Request-Id:
+      - fb4f1951-5939-410a-ae55-5f363765ac84
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214835Z:fb4f1951-5939-410a-ae55-5f363765ac84
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:34 GMT
+      Content-Length:
+      - '563'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:35 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2d254fea-c99b-40af-b172-656573ffb090
+      X-Ms-Correlation-Request-Id:
+      - 2d254fea-c99b-40af-b172-656573ffb090
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214836Z:2d254fea-c99b-40af-b172-656573ffb090
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:36 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - bec263b7-86b8-4cb7-a7c6-4786561b98cd
+      X-Ms-Correlation-Request-Id:
+      - bec263b7-86b8-4cb7-a7c6-4786561b98cd
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214836Z:bec263b7-86b8-4cb7-a7c6-4786561b98cd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:36 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 992b16a3-94c1-4423-b3e3-c6f11e41ae70
+      X-Ms-Correlation-Request-Id:
+      - 992b16a3-94c1-4423-b3e3-c6f11e41ae70
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214837Z:992b16a3-94c1-4423-b3e3-c6f11e41ae70
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:36 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3f05658a-b29c-4493-b263-10c78f10b97e
+      X-Ms-Correlation-Request-Id:
+      - 3f05658a-b29c-4493-b263-10c78f10b97e
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214837Z:3f05658a-b29c-4493-b263-10c78f10b97e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:36 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 51c05d96-9dc4-4a94-83ba-42c60fb9dc9c
+      X-Ms-Correlation-Request-Id:
+      - 51c05d96-9dc4-4a94-83ba-42c60fb9dc9c
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214838Z:51c05d96-9dc4-4a94-83ba-42c60fb9dc9c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:38 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9b64855b-67ef-4d66-970c-f346eea78eea
+      X-Ms-Correlation-Request-Id:
+      - 9b64855b-67ef-4d66-970c-f346eea78eea
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214838Z:9b64855b-67ef-4d66-970c-f346eea78eea
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:38 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f4e4b8fa-cfb6-44a9-b22a-5d94549cb1f9
+      X-Ms-Correlation-Request-Id:
+      - f4e4b8fa-cfb6-44a9-b22a-5d94549cb1f9
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214839Z:f4e4b8fa-cfb6-44a9-b22a-5d94549cb1f9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:38 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 880dabf4-a366-49f2-b4af-82193e2a9985
+      X-Ms-Correlation-Request-Id:
+      - 880dabf4-a366-49f2-b4af-82193e2a9985
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214839Z:880dabf4-a366-49f2-b4af-82193e2a9985
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:39 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODI5OTUsIm5iZiI6MTUxMjY4Mjk5NSwiZXhwIjoxNTEyNjg2ODk1LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibFJWeHRYQ05zVTZsODRleXNKME1BQSIsInZlciI6IjEuMCJ9.qPebZZxj7kl14qld5ELOlITzkLZmmlIzwQ14pZliqMYnVU2hVUzKAkkpJen-lv48hbtYEzlE3qylnYiRRAFrrN3q_7w4t0ZEKJu2Wqxh4W2tdQl76YbNusGNikZ0Pnm0ZdhkmW1CKYgVyW831L9PZT9-vzmBeRcmBCarEPfjwuFqTwQMbJhFKviGwYaeduc0mWGGlcriMxcTLsLlVxq6CS-wgpLzj6KDAoVoGo9xgkhcvnXi4copv8G8d-jbCJedL1voRNKns9kgPBai8vl-gEPe_YBkjUQn81EWnk-1tLvjOijcsuWj0FP85lUkQ3NTh6JnV2T6fZYkchXYrcf_Jg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5b89caa9-0ffa-4663-820e-eba5330fcab2
+      X-Ms-Correlation-Request-Id:
+      - 5b89caa9-0ffa-4663-820e-eba5330fcab2
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214839Z:5b89caa9-0ffa-4663-820e-eba5330fcab2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:39 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_backup_name_and_secondary_backup_name.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_backup_name_and_secondary_backup_name.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 9b0a9842-57cd-466c-a571-dc2f11d82d00
+      - 915a554f-5b3a-4713-9b66-4e980bf80b00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz5b24QxIALLP9NhU5TzbmYMJwA7i0KtnVpkTWEhXYBVki4spHpxMgJ-5ZnwI-3AtpkJ3gB7Gsuqcx3eZgfDBDbjyF0kEwXZn6PhQuxx2DImp0jvp8e8dAONeqps4FUqCIPlxxakuoBsFYqb4upRHpPDwA3uDvkmI4ci9DpbQU5aQgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzT4MS4J1gAFH3UBSKlNfH8OTfui50341pLINZsjAANBS5a8lQC63pgEhE8GgPTzLqhju2lo8H3N9GftrCt2pE5ahdto1LOA1r0Exlhvon5oRKtAyaCT1q_PDBuMmRHTzgqnQOdqBbxReEzYVvZ33t0EXP3B-ZEyuYebRU5F85a8QgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 01 Dec 2017 22:30:11 GMT
+      - Thu, 07 Dec 2017 21:48:39 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1512171011","not_before":"1512167111","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1512686920","not_before":"1512683020","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:12 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -91,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14998'
       X-Ms-Request-Id:
-      - ee10b399-abfb-4432-893e-89d256f2abdb
+      - e03a566b-7c15-4151-8072-f65583f0fad3
       X-Ms-Correlation-Request-Id:
-      - ee10b399-abfb-4432-893e-89d256f2abdb
+      - e03a566b-7c15-4151-8072-f65583f0fad3
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223012Z:ee10b399-abfb-4432-893e-89d256f2abdb
+      - WESTCENTRALUS:20171207T214840Z:e03a566b-7c15-4151-8072-f65583f0fad3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:12 GMT
+      - Thu, 07 Dec 2017 21:48:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:12 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -124,7 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -141,19 +141,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14909'
+      - '14977'
       X-Ms-Request-Id:
-      - d51115c1-6aa0-416f-b472-c536162063ed
+      - 8d84e983-474d-4755-ae3a-0eadb7d56b93
       X-Ms-Correlation-Request-Id:
-      - d51115c1-6aa0-416f-b472-c536162063ed
+      - 8d84e983-474d-4755-ae3a-0eadb7d56b93
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223013Z:d51115c1-6aa0-416f-b472-c536162063ed
+      - WESTCENTRALUS:20171207T214841Z:8d84e983-474d-4755-ae3a-0eadb7d56b93
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:12 GMT
+      - Thu, 07 Dec 2017 21:48:41 GMT
       Content-Length:
-      - '278554'
+      - '279208'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -260,7 +260,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -491,7 +491,7 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
-        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
         US","UK West","West India","Australia East","Brazil South","Canada East","East
@@ -614,92 +614,92 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","North
         Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
         South","Japan East","Japan West","North Europe","West Europe","Central India","South
@@ -816,7 +816,7 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
@@ -1459,7 +1459,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1606,7 +1606,8 @@ http_interactions:
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
         States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
         US","West US 2"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
@@ -1873,23 +1874,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1938,8 +1939,8 @@ http_interactions:
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
         Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
-        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"operations","locations":["Central
-        US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview","2017-05-10-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
@@ -2017,8 +2018,8 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -2030,18 +2031,18 @@ http_interactions:
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
         US","West Europe","Southeast Asia","Australia East"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
@@ -2122,7 +2123,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:13 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/locations?api-version=2015-01-01
@@ -2139,7 +2140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2156,17 +2157,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14928'
+      - '14958'
       X-Ms-Request-Id:
-      - f1a044fe-3b29-4274-8ee9-ce0362044ab2
+      - c2046121-0cb3-4a7c-a953-c49528eef0e4
       X-Ms-Correlation-Request-Id:
-      - f1a044fe-3b29-4274-8ee9-ce0362044ab2
+      - c2046121-0cb3-4a7c-a953-c49528eef0e4
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223014Z:f1a044fe-3b29-4274-8ee9-ce0362044ab2
+      - WESTCENTRALUS:20171207T214842Z:c2046121-0cb3-4a7c-a953-c49528eef0e4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:14 GMT
+      - Thu, 07 Dec 2017 21:48:41 GMT
       Content-Length:
       - '4523'
     body:
@@ -2199,10 +2200,10 @@ http_interactions:
         Central","longitude":"126.9780","latitude":"37.5665"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/locations/koreasouth","name":"koreasouth","displayName":"Korea
         South","longitude":"129.0756","latitude":"35.1796"}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:14 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2216,7 +2217,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2233,25 +2234,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8fc51ebd-e35c-4a79-a387-c921faece478
+      - fe2c47e6-689a-44ae-98a8-b386d858db17
       X-Ms-Correlation-Request-Id:
-      - 8fc51ebd-e35c-4a79-a387-c921faece478
+      - fe2c47e6-689a-44ae-98a8-b386d858db17
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223015Z:8fc51ebd-e35c-4a79-a387-c921faece478
+      - WESTCENTRALUS:20171207T214842Z:fe2c47e6-689a-44ae-98a8-b386d858db17
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:15 GMT
+      - Thu, 07 Dec 2017 21:48:42 GMT
       Content-Length:
-      - '549'
+      - '565'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:15 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2265,7 +2266,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2282,123 +2283,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4569fdbc-2ba8-4512-8ebb-d68471fffc2b
+      - d095443c-0996-4275-975f-5fa72f18aaa2
       X-Ms-Correlation-Request-Id:
-      - 4569fdbc-2ba8-4512-8ebb-d68471fffc2b
+      - d095443c-0996-4275-975f-5fa72f18aaa2
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223016Z:4569fdbc-2ba8-4512-8ebb-d68471fffc2b
+      - WESTCENTRALUS:20171207T214842Z:d095443c-0996-4275-975f-5fa72f18aaa2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:15 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:16 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - d0c75e95-3889-4ed6-bfb1-1e7c0ac7c247
-      X-Ms-Correlation-Request-Id:
-      - d0c75e95-3889-4ed6-bfb1-1e7c0ac7c247
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223016Z:d0c75e95-3889-4ed6-bfb1-1e7c0ac7c247
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:16 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:17 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 47de0887-6715-47d1-9d6e-7e3265756abe
-      X-Ms-Correlation-Request-Id:
-      - 47de0887-6715-47d1-9d6e-7e3265756abe
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223017Z:47de0887-6715-47d1-9d6e-7e3265756abe
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:16 GMT
+      - Thu, 07 Dec 2017 21:48:42 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:17 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2412,7 +2315,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2429,25 +2332,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e3b22a1f-dd36-427e-a8d9-7eb6cf2de7e7
+      - d631fa82-fbb0-4337-89c1-7f2af07d43cf
       X-Ms-Correlation-Request-Id:
-      - e3b22a1f-dd36-427e-a8d9-7eb6cf2de7e7
+      - d631fa82-fbb0-4337-89c1-7f2af07d43cf
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223018Z:e3b22a1f-dd36-427e-a8d9-7eb6cf2de7e7
+      - WESTCENTRALUS:20171207T214843Z:d631fa82-fbb0-4337-89c1-7f2af07d43cf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:17 GMT
+      - Thu, 07 Dec 2017 21:48:43 GMT
       Content-Length:
-      - '550'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southeastasia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:18 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:43 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southeastasia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2461,7 +2364,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2478,25 +2381,123 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 58fbb28c-85b0-4ef5-bd58-17e5a9a49eef
+      - 94dee6cb-1154-419e-a189-0a367fe078ea
       X-Ms-Correlation-Request-Id:
-      - 58fbb28c-85b0-4ef5-bd58-17e5a9a49eef
+      - 94dee6cb-1154-419e-a189-0a367fe078ea
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223019Z:58fbb28c-85b0-4ef5-bd58-17e5a9a49eef
+      - WESTCENTRALUS:20171207T214843Z:94dee6cb-1154-419e-a189-0a367fe078ea
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:18 GMT
+      - Thu, 07 Dec 2017 21:48:43 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 12acd939-ba62-4949-a536-29fa7669ff36
+      X-Ms-Correlation-Request-Id:
+      - 12acd939-ba62-4949-a536-29fa7669ff36
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214843Z:12acd939-ba62-4949-a536-29fa7669ff36
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:43 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 98d7a095-ce90-445f-8a3b-16def0c36fe9
+      X-Ms-Correlation-Request-Id:
+      - 98d7a095-ce90-445f-8a3b-16def0c36fe9
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214844Z:98d7a095-ce90-445f-8a3b-16def0c36fe9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:43 GMT
       Content-Length:
       - '1104'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2","name":"jf-metrics-2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3","name":"jf-metrics-3","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1","name":"miqazure-oraclelinux1","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2","name":"miqazure-oraclelinux2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"false"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:19 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2510,7 +2511,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2527,25 +2528,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f3066bcb-121a-4a06-87f1-e278d8a01e15
+      - aeaa6cea-cbdf-4423-922e-447052452d6f
       X-Ms-Correlation-Request-Id:
-      - f3066bcb-121a-4a06-87f1-e278d8a01e15
+      - aeaa6cea-cbdf-4423-922e-447052452d6f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223019Z:f3066bcb-121a-4a06-87f1-e278d8a01e15
+      - WESTCENTRALUS:20171207T214844Z:aeaa6cea-cbdf-4423-922e-447052452d6f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:19 GMT
+      - Thu, 07 Dec 2017 21:48:44 GMT
       Content-Length:
-      - '547'
+      - '563'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:19 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2559,7 +2560,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2576,25 +2577,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - dd04411d-70bb-4ae8-9455-e84f3d104c63
+      - d4d2fd03-43b4-403d-b878-4d394e726296
       X-Ms-Correlation-Request-Id:
-      - dd04411d-70bb-4ae8-9455-e84f3d104c63
+      - d4d2fd03-43b4-403d-b878-4d394e726296
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223020Z:dd04411d-70bb-4ae8-9455-e84f3d104c63
+      - WESTCENTRALUS:20171207T214845Z:d4d2fd03-43b4-403d-b878-4d394e726296
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:19 GMT
+      - Thu, 07 Dec 2017 21:48:44 GMT
       Content-Length:
       - '3378'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","name":"miq-test-rhel1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","name":"miq-test-ubuntu1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","name":"miq-test-win12","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","name":"miq-test-winimg","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","name":"miqazure-centos1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","name":"rspec-lb-a","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","name":"rspec-lb-b","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","name":"spec0deply1vm0","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","name":"spec0deply1vm1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2","name":"miqmismatch2","type":"Microsoft.Compute/virtualMachines","location":"eastus","plan":{"name":"rhel74","product":"rhel-byol-preview","publisher":"redhat"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/dbergerprov1","name":"dbergerprov1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","name":"miqazure-linux-managed","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1","name":"miqmismatch1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:20 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2608,7 +2609,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2625,25 +2626,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 565e4a6d-46b7-4700-9cf7-0419a78ee536
+      - f6ebe5d2-e2a6-40a7-ab92-360d56d87730
       X-Ms-Correlation-Request-Id:
-      - 565e4a6d-46b7-4700-9cf7-0419a78ee536
+      - f6ebe5d2-e2a6-40a7-ab92-360d56d87730
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223021Z:565e4a6d-46b7-4700-9cf7-0419a78ee536
+      - WESTCENTRALUS:20171207T214845Z:f6ebe5d2-e2a6-40a7-ab92-360d56d87730
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:21 GMT
+      - Thu, 07 Dec 2017 21:48:45 GMT
       Content-Length:
-      - '548'
+      - '564'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27eastus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:22 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27eastus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2657,7 +2658,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2674,25 +2675,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3abc7019-7aec-4fd2-8684-70f3176f1dee
+      - 8b83d6a6-9df8-4dc3-a0bb-ecf6b1260c42
       X-Ms-Correlation-Request-Id:
-      - 3abc7019-7aec-4fd2-8684-70f3176f1dee
+      - 8b83d6a6-9df8-4dc3-a0bb-ecf6b1260c42
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223022Z:3abc7019-7aec-4fd2-8684-70f3176f1dee
+      - WESTCENTRALUS:20171207T214846Z:8b83d6a6-9df8-4dc3-a0bb-ecf6b1260c42
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:21 GMT
+      - Thu, 07 Dec 2017 21:48:45 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:22 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2706,7 +2707,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2723,25 +2724,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8268b6f3-9e54-4cca-b108-276dfe218671
+      - 6c16e941-bc08-462f-9088-ca62b801cc36
       X-Ms-Correlation-Request-Id:
-      - 8268b6f3-9e54-4cca-b108-276dfe218671
+      - 6c16e941-bc08-462f-9088-ca62b801cc36
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223023Z:8268b6f3-9e54-4cca-b108-276dfe218671
+      - WESTCENTRALUS:20171207T214846Z:6c16e941-bc08-462f-9088-ca62b801cc36
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:22 GMT
+      - Thu, 07 Dec 2017 21:48:46 GMT
       Content-Length:
-      - '547'
+      - '563'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:23 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2755,7 +2756,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2772,25 +2773,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3f31fe03-c244-4abf-b36c-c3866d62816a
+      - c2b41a6a-d22b-4c76-9961-28fe7d19dde3
       X-Ms-Correlation-Request-Id:
-      - 3f31fe03-c244-4abf-b36c-c3866d62816a
+      - c2b41a6a-d22b-4c76-9961-28fe7d19dde3
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223024Z:3f31fe03-c244-4abf-b36c-c3866d62816a
+      - WESTCENTRALUS:20171207T214847Z:c2b41a6a-d22b-4c76-9961-28fe7d19dde3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:23 GMT
+      - Thu, 07 Dec 2017 21:48:46 GMT
       Content-Length:
       - '280'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1","name":"miqazure-coreos1","type":"Microsoft.Compute/virtualMachines","location":"westus","tags":{"Shutdown":"true"}}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:24 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2804,7 +2805,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2821,25 +2822,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4837f9f5-b20e-4780-9c9e-d35f1a5a1265
+      - 8fa25c13-11d3-4d23-aa58-caf5eb9184b3
       X-Ms-Correlation-Request-Id:
-      - 4837f9f5-b20e-4780-9c9e-d35f1a5a1265
+      - 8fa25c13-11d3-4d23-aa58-caf5eb9184b3
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223025Z:4837f9f5-b20e-4780-9c9e-d35f1a5a1265
+      - WESTCENTRALUS:20171207T214847Z:8fa25c13-11d3-4d23-aa58-caf5eb9184b3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:25 GMT
+      - Thu, 07 Dec 2017 21:48:47 GMT
       Content-Length:
-      - '555'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:25 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2853,7 +2854,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -2870,123 +2871,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2766e881-ff01-42aa-a240-c0b6f8363945
+      - 4928ad2e-136a-4c13-8ebe-b95a3daef997
       X-Ms-Correlation-Request-Id:
-      - 2766e881-ff01-42aa-a240-c0b6f8363945
+      - 4928ad2e-136a-4c13-8ebe-b95a3daef997
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223025Z:2766e881-ff01-42aa-a240-c0b6f8363945
+      - WESTCENTRALUS:20171207T214848Z:4928ad2e-136a-4c13-8ebe-b95a3daef997
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:25 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2c7fd5e9-75d8-4830-a77d-99965e3ebb35
-      X-Ms-Correlation-Request-Id:
-      - 2c7fd5e9-75d8-4830-a77d-99965e3ebb35
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223026Z:2c7fd5e9-75d8-4830-a77d-99965e3ebb35
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:25 GMT
-      Content-Length:
-      - '555'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 41b78ba3-a819-463f-8b05-14eee4e18d63
-      X-Ms-Correlation-Request-Id:
-      - 41b78ba3-a819-463f-8b05-14eee4e18d63
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223027Z:41b78ba3-a819-463f-8b05-14eee4e18d63
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:26 GMT
+      - Thu, 07 Dec 2017 21:48:47 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:27 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3000,7 +2903,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3017,25 +2920,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5ba02e22-ceb7-4941-87b9-2d97cb37c553
+      - f5258493-302d-43b7-9369-c37fc37db12b
       X-Ms-Correlation-Request-Id:
-      - 5ba02e22-ceb7-4941-87b9-2d97cb37c553
+      - f5258493-302d-43b7-9369-c37fc37db12b
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223028Z:5ba02e22-ceb7-4941-87b9-2d97cb37c553
+      - WESTCENTRALUS:20171207T214848Z:f5258493-302d-43b7-9369-c37fc37db12b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:27 GMT
+      - Thu, 07 Dec 2017 21:48:48 GMT
       Content-Length:
-      - '552'
+      - '571'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:28 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3049,7 +2952,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3066,123 +2969,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e4d33e82-dfe1-45da-a614-a87df38cba52
+      - 953f7cff-ba1a-4fcf-9238-c458cee8ee06
       X-Ms-Correlation-Request-Id:
-      - e4d33e82-dfe1-45da-a614-a87df38cba52
+      - 953f7cff-ba1a-4fcf-9238-c458cee8ee06
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223029Z:e4d33e82-dfe1-45da-a614-a87df38cba52
+      - WESTCENTRALUS:20171207T214848Z:953f7cff-ba1a-4fcf-9238-c458cee8ee06
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:28 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 91fe13a8-a0ca-416a-9d09-984811cf518c
-      X-Ms-Correlation-Request-Id:
-      - 91fe13a8-a0ca-416a-9d09-984811cf518c
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223030Z:91fe13a8-a0ca-416a-9d09-984811cf518c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:29 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - dfab8795-1e80-49fd-b5eb-09aafe0617df
-      X-Ms-Correlation-Request-Id:
-      - dfab8795-1e80-49fd-b5eb-09aafe0617df
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223031Z:dfab8795-1e80-49fd-b5eb-09aafe0617df
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:30 GMT
+      - Thu, 07 Dec 2017 21:48:48 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:31 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3196,7 +3001,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3213,25 +3018,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e93869de-5dcd-4cc5-9951-f0d1a7097412
+      - 6cfa8966-c6cb-43d0-8dc2-465ea14fec75
       X-Ms-Correlation-Request-Id:
-      - e93869de-5dcd-4cc5-9951-f0d1a7097412
+      - 6cfa8966-c6cb-43d0-8dc2-465ea14fec75
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223031Z:e93869de-5dcd-4cc5-9951-f0d1a7097412
+      - WESTCENTRALUS:20171207T214849Z:6cfa8966-c6cb-43d0-8dc2-465ea14fec75
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:30 GMT
+      - Thu, 07 Dec 2017 21:48:48 GMT
       Content-Length:
-      - '550'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27northeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:31 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27northeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3245,7 +3050,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3262,123 +3067,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - dff8df2c-b4eb-40be-aa50-1e64b2c59d77
+      - fc380cc8-6288-441e-ad3c-e2a84ebce4fb
       X-Ms-Correlation-Request-Id:
-      - dff8df2c-b4eb-40be-aa50-1e64b2c59d77
+      - fc380cc8-6288-441e-ad3c-e2a84ebce4fb
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223032Z:dff8df2c-b4eb-40be-aa50-1e64b2c59d77
+      - WESTCENTRALUS:20171207T214849Z:fc380cc8-6288-441e-ad3c-e2a84ebce4fb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:31 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 228b28c8-ec97-4dbb-bc31-b4d6f636f68c
-      X-Ms-Correlation-Request-Id:
-      - 228b28c8-ec97-4dbb-bc31-b4d6f636f68c
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223033Z:228b28c8-ec97-4dbb-bc31-b4d6f636f68c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:32 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 34e44a81-5e17-4b59-8079-a7bdbd972502
-      X-Ms-Correlation-Request-Id:
-      - 34e44a81-5e17-4b59-8079-a7bdbd972502
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223033Z:34e44a81-5e17-4b59-8079-a7bdbd972502
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:32 GMT
+      - Thu, 07 Dec 2017 21:48:49 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:33 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3392,7 +3099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3409,25 +3116,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - fb3253b3-b6ac-4210-9bee-dcc756f9008f
+      - c1fb1269-ddcf-4030-a2e6-61108ce490f7
       X-Ms-Correlation-Request-Id:
-      - fb3253b3-b6ac-4210-9bee-dcc756f9008f
+      - c1fb1269-ddcf-4030-a2e6-61108ce490f7
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223034Z:fb3253b3-b6ac-4210-9bee-dcc756f9008f
+      - WESTCENTRALUS:20171207T214849Z:c1fb1269-ddcf-4030-a2e6-61108ce490f7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:33 GMT
+      - Thu, 07 Dec 2017 21:48:49 GMT
       Content-Length:
-      - '552'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westeurope%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:34 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westeurope%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3441,7 +3148,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3458,123 +3165,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 514b56f6-87e0-4b58-8a39-15b8cf7e9c30
+      - e29c9e29-dfdb-4668-999f-1e3b9cb1585f
       X-Ms-Correlation-Request-Id:
-      - 514b56f6-87e0-4b58-8a39-15b8cf7e9c30
+      - e29c9e29-dfdb-4668-999f-1e3b9cb1585f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223035Z:514b56f6-87e0-4b58-8a39-15b8cf7e9c30
+      - WESTCENTRALUS:20171207T214850Z:e29c9e29-dfdb-4668-999f-1e3b9cb1585f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:34 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 80408974-24cc-462a-a627-fb09f8e784da
-      X-Ms-Correlation-Request-Id:
-      - 80408974-24cc-462a-a627-fb09f8e784da
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223035Z:80408974-24cc-462a-a627-fb09f8e784da
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:35 GMT
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - db43a1c3-d117-45fd-987a-54b3b78a6ccb
-      X-Ms-Correlation-Request-Id:
-      - db43a1c3-d117-45fd-987a-54b3b78a6ccb
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223037Z:db43a1c3-d117-45fd-987a-54b3b78a6ccb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:36 GMT
+      - Thu, 07 Dec 2017 21:48:50 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:37 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3588,7 +3197,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3605,25 +3214,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 777c6552-95cd-4678-a03c-6c4dfdadb67a
+      - d5358dc2-b7c4-4e8d-b7db-928dc34725b3
       X-Ms-Correlation-Request-Id:
-      - 777c6552-95cd-4678-a03c-6c4dfdadb67a
+      - d5358dc2-b7c4-4e8d-b7db-928dc34725b3
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223037Z:777c6552-95cd-4678-a03c-6c4dfdadb67a
+      - WESTCENTRALUS:20171207T214850Z:d5358dc2-b7c4-4e8d-b7db-928dc34725b3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:37 GMT
+      - Thu, 07 Dec 2017 21:48:50 GMT
       Content-Length:
-      - '559'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japanwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:38 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japanwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3637,7 +3246,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3654,123 +3263,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - abfb704a-b19b-45a3-90b0-8e83fe15d2eb
+      - b6926ac9-e6e3-4f5f-b66d-5517c7f73dca
       X-Ms-Correlation-Request-Id:
-      - abfb704a-b19b-45a3-90b0-8e83fe15d2eb
+      - b6926ac9-e6e3-4f5f-b66d-5517c7f73dca
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223038Z:abfb704a-b19b-45a3-90b0-8e83fe15d2eb
+      - WESTCENTRALUS:20171207T214851Z:b6926ac9-e6e3-4f5f-b66d-5517c7f73dca
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:37 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ae5fa88f-25fa-4815-b32e-df8bdfa89593
-      X-Ms-Correlation-Request-Id:
-      - ae5fa88f-25fa-4815-b32e-df8bdfa89593
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223039Z:ae5fa88f-25fa-4815-b32e-df8bdfa89593
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:38 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - eaba431a-4b9f-41df-96df-d7a9eade8b73
-      X-Ms-Correlation-Request-Id:
-      - eaba431a-4b9f-41df-96df-d7a9eade8b73
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223040Z:eaba431a-4b9f-41df-96df-d7a9eade8b73
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:39 GMT
+      - Thu, 07 Dec 2017 21:48:51 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:40 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:51 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3784,7 +3295,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3801,25 +3312,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2b2ed494-c129-4a74-8393-d08ff24c20c9
+      - e9788220-9891-4b76-a703-41b74494489f
       X-Ms-Correlation-Request-Id:
-      - 2b2ed494-c129-4a74-8393-d08ff24c20c9
+      - e9788220-9891-4b76-a703-41b74494489f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223041Z:2b2ed494-c129-4a74-8393-d08ff24c20c9
+      - WESTCENTRALUS:20171207T214851Z:e9788220-9891-4b76-a703-41b74494489f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:40 GMT
+      - Thu, 07 Dec 2017 21:48:51 GMT
       Content-Length:
-      - '553'
+      - '566'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27japaneast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:41 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:51 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27japaneast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3833,7 +3344,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3850,123 +3361,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7c5fd9d9-9c35-41e4-b169-993387961249
+      - 4d5066c0-d2b8-415c-af61-7fd40f474d48
       X-Ms-Correlation-Request-Id:
-      - 7c5fd9d9-9c35-41e4-b169-993387961249
+      - 4d5066c0-d2b8-415c-af61-7fd40f474d48
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223041Z:7c5fd9d9-9c35-41e4-b169-993387961249
+      - WESTCENTRALUS:20171207T214852Z:4d5066c0-d2b8-415c-af61-7fd40f474d48
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:41 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 194750d3-7cd2-4b0d-8ad6-041d1fa9d702
-      X-Ms-Correlation-Request-Id:
-      - 194750d3-7cd2-4b0d-8ad6-041d1fa9d702
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223042Z:194750d3-7cd2-4b0d-8ad6-041d1fa9d702
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:42 GMT
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7c57c864-e038-4f87-9fc1-54c12db03046
-      X-Ms-Correlation-Request-Id:
-      - 7c57c864-e038-4f87-9fc1-54c12db03046
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223043Z:7c57c864-e038-4f87-9fc1-54c12db03046
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:42 GMT
+      - Thu, 07 Dec 2017 21:48:51 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:43 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:52 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3980,7 +3393,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -3997,25 +3410,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 53806d8e-1838-4f9a-9b37-6bee1b2c3a45
+      - 9e19e872-ea58-41b2-ab9c-bce795173e1c
       X-Ms-Correlation-Request-Id:
-      - 53806d8e-1838-4f9a-9b37-6bee1b2c3a45
+      - 9e19e872-ea58-41b2-ab9c-bce795173e1c
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223043Z:53806d8e-1838-4f9a-9b37-6bee1b2c3a45
+      - WESTCENTRALUS:20171207T214852Z:9e19e872-ea58-41b2-ab9c-bce795173e1c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:43 GMT
+      - Thu, 07 Dec 2017 21:48:51 GMT
       Content-Length:
-      - '554'
+      - '568'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27brazilsouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:43 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:52 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27brazilsouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4029,7 +3442,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -4046,123 +3459,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d9e3efd2-d0f7-4153-b6fa-72c192b03d2a
+      - b7842d7a-3a97-462b-b95a-9e84f4b930e1
       X-Ms-Correlation-Request-Id:
-      - d9e3efd2-d0f7-4153-b6fa-72c192b03d2a
+      - b7842d7a-3a97-462b-b95a-9e84f4b930e1
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223044Z:d9e3efd2-d0f7-4153-b6fa-72c192b03d2a
+      - WESTCENTRALUS:20171207T214852Z:b7842d7a-3a97-462b-b95a-9e84f4b930e1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:44 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4a87650c-3a41-4cb0-97d2-fe824756cd9e
-      X-Ms-Correlation-Request-Id:
-      - 4a87650c-3a41-4cb0-97d2-fe824756cd9e
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223045Z:4a87650c-3a41-4cb0-97d2-fe824756cd9e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:45 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f63eb709-f427-448d-8ec7-f18ac2de7c46
-      X-Ms-Correlation-Request-Id:
-      - f63eb709-f427-448d-8ec7-f18ac2de7c46
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223046Z:f63eb709-f427-448d-8ec7-f18ac2de7c46
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:45 GMT
+      - Thu, 07 Dec 2017 21:48:52 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:46 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:53 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4176,7 +3491,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -4193,25 +3508,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1c597aab-baa6-4bb5-9bb9-3bb5dad6753c
+      - a5105815-f7bb-46de-9ec8-d3a86a465dee
       X-Ms-Correlation-Request-Id:
-      - 1c597aab-baa6-4bb5-9bb9-3bb5dad6753c
+      - a5105815-f7bb-46de-9ec8-d3a86a465dee
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223047Z:1c597aab-baa6-4bb5-9bb9-3bb5dad6753c
+      - WESTCENTRALUS:20171207T214853Z:a5105815-f7bb-46de-9ec8-d3a86a465dee
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:46 GMT
+      - Thu, 07 Dec 2017 21:48:53 GMT
       Content-Length:
-      - '548'
+      - '570'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:47 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:53 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4225,7 +3540,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -4242,123 +3557,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5e6ccd0d-ff10-4149-b5a9-de0f6b139bff
+      - 59f3f7ca-7626-4d55-861a-730f618dafb3
       X-Ms-Correlation-Request-Id:
-      - 5e6ccd0d-ff10-4149-b5a9-de0f6b139bff
+      - 59f3f7ca-7626-4d55-861a-730f618dafb3
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223048Z:5e6ccd0d-ff10-4149-b5a9-de0f6b139bff
+      - WESTCENTRALUS:20171207T214853Z:59f3f7ca-7626-4d55-861a-730f618dafb3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:48 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 774c5f49-24a8-42da-bbef-8904eb31a842
-      X-Ms-Correlation-Request-Id:
-      - 774c5f49-24a8-42da-bbef-8904eb31a842
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223048Z:774c5f49-24a8-42da-bbef-8904eb31a842
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:48 GMT
-      Content-Length:
-      - '547'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 39435151-20cb-4767-8cc3-9a8badc15cc1
-      X-Ms-Correlation-Request-Id:
-      - 39435151-20cb-4767-8cc3-9a8badc15cc1
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223050Z:39435151-20cb-4767-8cc3-9a8badc15cc1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:49 GMT
+      - Thu, 07 Dec 2017 21:48:53 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:50 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:54 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4372,7 +3589,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -4389,25 +3606,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 19b4203f-c6ac-44d5-b216-341b222a26bb
+      - da41a39c-856c-4862-bcf8-8a9242e6de77
       X-Ms-Correlation-Request-Id:
-      - 19b4203f-c6ac-44d5-b216-341b222a26bb
+      - da41a39c-856c-4862-bcf8-8a9242e6de77
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223050Z:19b4203f-c6ac-44d5-b216-341b222a26bb
+      - WESTCENTRALUS:20171207T214854Z:da41a39c-856c-4862-bcf8-8a9242e6de77
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:49 GMT
+      - Thu, 07 Dec 2017 21:48:53 GMT
       Content-Length:
-      - '554'
+      - '575'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27australiasoutheast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:50 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:54 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27australiasoutheast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4421,7 +3638,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -4438,123 +3655,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 70478df1-ae77-488a-a536-c92179f42689
+      - 8f2ab2c7-c924-432a-bebe-ce76fb18c81e
       X-Ms-Correlation-Request-Id:
-      - 70478df1-ae77-488a-a536-c92179f42689
+      - 8f2ab2c7-c924-432a-bebe-ce76fb18c81e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223051Z:70478df1-ae77-488a-a536-c92179f42689
+      - WESTCENTRALUS:20171207T214854Z:8f2ab2c7-c924-432a-bebe-ce76fb18c81e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:50 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2946388f-5994-4398-b92e-faeb18cad982
-      X-Ms-Correlation-Request-Id:
-      - 2946388f-5994-4398-b92e-faeb18cad982
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223052Z:2946388f-5994-4398-b92e-faeb18cad982
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:51 GMT
-      Content-Length:
-      - '548'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4ec003c9-49ea-459f-822f-bb9602b75ab4
-      X-Ms-Correlation-Request-Id:
-      - 4ec003c9-49ea-459f-822f-bb9602b75ab4
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223053Z:4ec003c9-49ea-459f-822f-bb9602b75ab4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:52 GMT
+      - Thu, 07 Dec 2017 21:48:54 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:53 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:54 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4568,7 +3687,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -4585,25 +3704,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - cc8b0780-bb88-42ec-a6c0-2664b470280a
+      - deb52b7b-fce7-46e1-b10d-cf540a07afad
       X-Ms-Correlation-Request-Id:
-      - cc8b0780-bb88-42ec-a6c0-2664b470280a
+      - deb52b7b-fce7-46e1-b10d-cf540a07afad
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223054Z:cc8b0780-bb88-42ec-a6c0-2664b470280a
+      - WESTCENTRALUS:20171207T214855Z:deb52b7b-fce7-46e1-b10d-cf540a07afad
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:53 GMT
+      - Thu, 07 Dec 2017 21:48:54 GMT
       Content-Length:
-      - '553'
+      - '567'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27southindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:54 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27southindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4617,7 +3736,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
   response:
     status:
       code: 200
@@ -4634,118 +3753,1000 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e808c6ef-6012-4744-9bbe-94cb6dac10c1
+      - 98605ef5-31b3-4216-a684-a3e672aa232e
       X-Ms-Correlation-Request-Id:
-      - e808c6ef-6012-4744-9bbe-94cb6dac10c1
+      - 98605ef5-31b3-4216-a684-a3e672aa232e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223054Z:e808c6ef-6012-4744-9bbe-94cb6dac10c1
+      - WESTCENTRALUS:20171207T214855Z:98605ef5-31b3-4216-a684-a3e672aa232e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 01 Dec 2017 22:30:54 GMT
-      Content-Length:
-      - '12'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 138a2537-f5c0-42b9-93c1-30711bb873fc
-      X-Ms-Correlation-Request-Id:
-      - 138a2537-f5c0-42b9-93c1-30711bb873fc
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223055Z:138a2537-f5c0-42b9-93c1-30711bb873fc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:54 GMT
-      Content-Length:
-      - '551'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2017-08-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0%3d"}'
-    http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTY0IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUpVVG95UkVGYVZWSkZPakpFVkVWVFZERXRUVWxEVWs5VFQwWlVPakpGUTA5TlVGVlVSVG95UmtGV1FVbE1RVUpKVEVsVVdWTkZWRk02TWtaU1UxQkZRem95UkV4Q01Ub3lSRUZUTFVWQlUxUlZVdy0tIn0=&api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTIxNjcxMTEsIm5iZiI6MTUxMjE2NzExMSwiZXhwIjoxNTEyMTcxMDExLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUXBnS204MVhiRWFsY2R3dkVkZ3RBQSIsInZlciI6IjEuMCJ9.M3HCT4-Is9zKPzEWcjwXF3fru8WE4HqZWU9d8L87t46tF-52tZUqFWMoFUaBdwxR8J1UqQSsJ_PIPBNOniBIwOSbqIO8CDJoGwfTucA0Xk6vbLLchDoGJOTwb-1Hv-IS95dWSZjjsWb9L2npC-5r24DKyB5jQ_AvhEQj5evJgJ5492URRozyZrJFgcPJNKjsqQMWKh7ICk_sBuynz6PHd5IBmsa0IPj7FYQZbldVLFD7ovnkOBJ8lFP6oC08mF9XitNCE5xV5ypF4F-f_c9mD2Wj3fMSLLWwohMtCdSdzfZTXE2FqC22_9eiLqo9eT_rXSfRq0_F5N7J24XwFXo3Ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4381b115-9d8a-4c75-b955-657f779b794c
-      X-Ms-Correlation-Request-Id:
-      - 4381b115-9d8a-4c75-b955-657f779b794c
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20171201T223056Z:4381b115-9d8a-4c75-b955-657f779b794c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 01 Dec 2017 22:30:55 GMT
+      - Thu, 07 Dec 2017 21:48:55 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 22:30:56 GMT
+  recorded_at: Thu, 07 Dec 2017 21:48:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f64b5b3b-801b-4299-ba59-1895c3346bed
+      X-Ms-Correlation-Request-Id:
+      - f64b5b3b-801b-4299-ba59-1895c3346bed
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214855Z:f64b5b3b-801b-4299-ba59-1895c3346bed
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:55 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27centralindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27centralindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2e9f9a9a-2681-4620-bcff-65934b1788a6
+      X-Ms-Correlation-Request-Id:
+      - 2e9f9a9a-2681-4620-bcff-65934b1788a6
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214856Z:2e9f9a9a-2681-4620-bcff-65934b1788a6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:56 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1cc6fb63-9e35-4f7b-99f2-570772312bf0
+      X-Ms-Correlation-Request-Id:
+      - 1cc6fb63-9e35-4f7b-99f2-570772312bf0
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214857Z:1cc6fb63-9e35-4f7b-99f2-570772312bf0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:56 GMT
+      Content-Length:
+      - '566'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westindia%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westindia%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8c8433bd-20e7-43c8-8612-e58d70df7489
+      X-Ms-Correlation-Request-Id:
+      - 8c8433bd-20e7-43c8-8612-e58d70df7489
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214857Z:8c8433bd-20e7-43c8-8612-e58d70df7489
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:57 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 33c34094-1d27-417d-a176-e05c1ab27387
+      X-Ms-Correlation-Request-Id:
+      - 33c34094-1d27-417d-a176-e05c1ab27387
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214858Z:33c34094-1d27-417d-a176-e05c1ab27387
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:57 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 27d59fd0-d9f3-4703-bad8-0f74cb215725
+      X-Ms-Correlation-Request-Id:
+      - 27d59fd0-d9f3-4703-bad8-0f74cb215725
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214858Z:27d59fd0-d9f3-4703-bad8-0f74cb215725
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:58 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a847c54d-a08f-4dfa-aa20-ca80c3461a16
+      X-Ms-Correlation-Request-Id:
+      - a847c54d-a08f-4dfa-aa20-ca80c3461a16
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214858Z:a847c54d-a08f-4dfa-aa20-ca80c3461a16
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:58 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27canadaeast%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27canadaeast%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 26194b29-14cc-44c6-9e1b-a24a84f3037b
+      X-Ms-Correlation-Request-Id:
+      - 26194b29-14cc-44c6-9e1b-a24a84f3037b
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214859Z:26194b29-14cc-44c6-9e1b-a24a84f3037b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:58 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 52b5a45e-13f9-4fcf-9f67-c668572182d6
+      X-Ms-Correlation-Request-Id:
+      - 52b5a45e-13f9-4fcf-9f67-c668572182d6
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214859Z:52b5a45e-13f9-4fcf-9f67-c668572182d6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:59 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27uksouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:48:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27uksouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 87e2165e-03ae-4230-84da-1837c79ed501
+      X-Ms-Correlation-Request-Id:
+      - 87e2165e-03ae-4230-84da-1837c79ed501
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214900Z:87e2165e-03ae-4230-84da-1837c79ed501
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:48:59 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 12db2287-f2e2-4189-a6e7-6740a8c77e9f
+      X-Ms-Correlation-Request-Id:
+      - 12db2287-f2e2-4189-a6e7-6740a8c77e9f
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214900Z:12db2287-f2e2-4189-a6e7-6740a8c77e9f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:00 GMT
+      Content-Length:
+      - '563'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27ukwest%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27ukwest%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e521380c-9ddd-48e0-8e8d-4c2913af329d
+      X-Ms-Correlation-Request-Id:
+      - e521380c-9ddd-48e0-8e8d-4c2913af329d
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214900Z:e521380c-9ddd-48e0-8e8d-4c2913af329d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:00 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3099080d-6582-4e49-970e-9b3c5d17e5a7
+      X-Ms-Correlation-Request-Id:
+      - 3099080d-6582-4e49-970e-9b3c5d17e5a7
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214901Z:3099080d-6582-4e49-970e-9b3c5d17e5a7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:00 GMT
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westcentralus%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westcentralus%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9d92960a-c257-4de2-9ddb-8f097e7cea2f
+      X-Ms-Correlation-Request-Id:
+      - 9d92960a-c257-4de2-9ddb-8f097e7cea2f
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214901Z:9d92960a-c257-4de2-9ddb-8f097e7cea2f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:01 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 70b83a41-860c-4d98-b22b-71f74bbedfff
+      X-Ms-Correlation-Request-Id:
+      - 70b83a41-860c-4d98-b22b-71f74bbedfff
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214902Z:70b83a41-860c-4d98-b22b-71f74bbedfff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:02 GMT
+      Content-Length:
+      - '564'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27westus2%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27westus2%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f6b6202d-5b29-4a78-83a1-7cf2e5c5fc6d
+      X-Ms-Correlation-Request-Id:
+      - f6b6202d-5b29-4a78-83a1-7cf2e5c5fc6d
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214902Z:f6b6202d-5b29-4a78-83a1-7cf2e5c5fc6d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:02 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9c97ab45-3828-4adf-9916-4c1d917118aa
+      X-Ms-Correlation-Request-Id:
+      - 9c97ab45-3828-4adf-9916-4c1d917118aa
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214903Z:9c97ab45-3828-4adf-9916-4c1d917118aa
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:02 GMT
+      Content-Length:
+      - '569'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreacentral%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreacentral%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 17bcd472-57b3-4a12-8895-ec77577375c2
+      X-Ms-Correlation-Request-Id:
+      - 17bcd472-57b3-4a12-8895-ec77577375c2
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214903Z:17bcd472-57b3-4a12-8895-ec77577375c2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:03 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a32d4782-8cdf-4569-9297-ca99713c81bf
+      X-Ms-Correlation-Request-Id:
+      - a32d4782-8cdf-4569-9297-ca99713c81bf
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214904Z:a32d4782-8cdf-4569-9297-ca99713c81bf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:03 GMT
+      Content-Length:
+      - '567'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?api-version=2016-09-01&%24filter=resourceType+eq+%27Microsoft.Compute%2fvirtualMachines%27+and+location+eq+%27koreasouth%27&%24skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0%3d"}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27%20and%20location%20eq%20%27koreasouth%27&$skiptoken=eyJuZXh0UGFydGl0aW9uS2V5IjoiMSE4IU1rRkRRVGMtIiwibmV4dFJvd0tleSI6IjEhMTc2IU1qVTROa00yTkVJek9FSTBORFV5TjBFeE5EQXdNVEpFTkRsRVJrTXdNa05mUjFKTUxVMUJTRVZPUkZKQk9qSkVSMVZKT2pKRVZFVlRWRWxPUnkxTlNVTlNUMU5QUmxRNk1rVlRWRTlTUVVkRk9qSkdVMVJQVWtGSFJVRkRRMDlWVGxSVE9qSkdUVUZJUlU1RVVrRkhWVWxVUlZOVVNVNUhPRFF5TFZkRlUxUlZVdy0tIn0=&api-version=2016-09-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyIsImtpZCI6Ing0Nzh4eU9wbHNNMUg3TlhrN1N4MTd4MXVwYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTI2ODMwMjAsIm5iZiI6MTUxMjY4MzAyMCwiZXhwIjoxNTEyNjg2OTIwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVDFWYWtUcGJFMGViWms2WUNfZ0xBQSIsInZlciI6IjEuMCJ9.F64Q3cy7GlKLDWVB3zE7VwNARBxDWAPy7rp-zbECnoYjgGuOVixbCP8OIx3WyoRC_MJTwNmk_QFlNZdCC9H3_HF69lwFVb2C2uMAkbkVWwPdMT5i9v0GARx-k7osK_7A8blSiwN0ZvGVf4xTqRbCt4xAqFpu2JDhxyQIPsYUjcbw-xAvfPurY27uPhNPiBULAOJGduicyrkp-fOcQ48EOIUFkBCEGmcdOs_qomPAAEi1_18tR8awQMw7tQE2NqVEf2gXw2FEJ8akmtD3SLpf3shmZ3pqtQKTHc-QImtyImxq2nluV7RjoJJnc5j-_EdV4BGHGVF1hlKyM_MAXRB4fA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - cf2d26c7-b1b2-4c57-bb46-1163549fa88d
+      X-Ms-Correlation-Request-Id:
+      - cf2d26c7-b1b2-4c57-bb46-1163549fa88d
+      X-Ms-Routing-Request-Id:
+      - WESTCENTRALUS:20171207T214904Z:cf2d26c7-b1b2-4c57-bb46-1163549fa88d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 07 Dec 2017 21:49:04 GMT
+      Content-Length:
+      - '12'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[]}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:49:04 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This is a followup to https://github.com/ManageIQ/manageiq-providers-azure/pull/179. It turns out the Service class we were using for discovery code did not explicitly set the api-version. This caused the requests to use the latest api-version, instead of the one we want locked in. This corrects that, and regenerates the VCR cassettes.

A separate PR will have to be generated for Fine/Euwe, because it uses a different service class.