### PR TITLE
Added supported_catalog_types

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -77,6 +77,10 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     ManageIQ::Providers::Azure::Regions.find_by_name(provider_region)[:description]
   end
 
+  def supported_catalog_types
+    %w(azure)
+  end
+
   # Operations
 
   def vm_start(vm, _options = {})

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -302,4 +302,12 @@ describe ManageIQ::Providers::Azure::CloudManager do
       end
     end
   end
+
+  context 'catalog types' do
+    let(:ems) { FactoryGirl.create(:ems_azure) }
+
+    it "#supported_catalog_types" do
+      expect(ems.supported_catalog_types).to eq(%w(azure))
+    end
+  end
 end


### PR DESCRIPTION
For Service catalogs each provider needs to return the supported_catalog_types
Needed for PR https://github.com/ManageIQ/manageiq/pull/16559