### PR TITLE
Log warning if no provider region is specified

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -22,6 +22,10 @@ module ManageIQ::Providers::Azure::ManagerMixin
         raise MiqException::MiqInvalidCredentialsError, _("Incorrect credentials - check your Azure Subscription ID")
       end
 
+      if provider_region.blank?
+        $azure_log.warn("No region selected. Validating credentials against public environment.")
+      end
+
       ::Azure::Armrest::Configuration.log = $azure_log
 
       connection_rescue_block do


### PR DESCRIPTION
If no provider region is specified when calling `raw_connect`, write a warning to the $azure_log to indicate that the validation was automatically performed against the public Azure environment.

Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1515670

The UI side was handled by https://github.com/ManageIQ/manageiq-ui-classic/pull/3125