### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -219,4 +219,8 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
     connection ||= connect
     ::Azure::Armrest::Storage::SnapshotService.new(connection)
   end
+
+  def self.display_name(number = 1)
+    n_('Cloud Provider (Microsoft Azure)', 'Cloud Providers (Microsoft Azure)', number)
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
@@ -69,4 +69,8 @@ class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ManageIQ::P
     _log.error "stack=[#{name}], error: #{err}"
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
+
+  def self.display_name(number = 1)
+    n_('Orchestration Stack (Microsoft Azure)', 'Orchestration Stacks (Microsoft Azure)', number)
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_template.rb
@@ -46,6 +46,10 @@ class ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate < ::Orches
     err.message
   end
 
+  def self.display_name(number = 1)
+    n_('Azure Template', 'Azure Templates', number)
+  end
+
   private
 
   def mode_opt

--- a/app/models/manageiq/providers/azure/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm.rb
@@ -38,4 +38,8 @@ class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudM
       "unknown"
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Instance (Microsoft Azure)', 'Instances (Microsoft Azure)', number)
+  end
 end

--- a/app/models/manageiq/providers/azure/network_manager.rb
+++ b/app/models/manageiq/providers/azure/network_manager.rb
@@ -54,4 +54,8 @@ class ManageIQ::Providers::Azure::NetworkManager < ManageIQ::Providers::NetworkM
   def description
     ManageIQ::Providers::Azure::Regions.find_by_name(provider_region)[:description]
   end
+
+  def self.display_name(number = 1)
+    n_('Network Manager (Microsoft Azure)', 'Network Managers (Microsoft Azure)', number)
+  end
 end

--- a/app/models/manageiq/providers/azure/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/azure/network_manager/cloud_network.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Azure::NetworkManager::CloudNetwork < ::CloudNetwork
+  def self.display_name(number = 1)
+    n_('Cloud Network (Microsoft Azure)', 'Cloud Networks (Microsoft Azure)', number)
+  end
 end

--- a/app/models/manageiq/providers/azure/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/azure/network_manager/cloud_subnet.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Azure::NetworkManager::CloudSubnet < ::CloudSubnet
+  def self.display_name(number = 1)
+    n_('Cloud Subnet (Microsoft Azure)', 'Cloud Subnets (Microsoft Azure)', number)
+  end
 end

--- a/app/models/manageiq/providers/azure/network_manager/load_balancer.rb
+++ b/app/models/manageiq/providers/azure/network_manager/load_balancer.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Azure::NetworkManager::LoadBalancer < ::LoadBalancer
+  def self.display_name(number = 1)
+    n_('Load Balancer (Microsoft Azure)', 'Load Balancers (Microsoft Azure)', number)
+  end
 end

--- a/app/models/manageiq/providers/azure/network_manager/network_port.rb
+++ b/app/models/manageiq/providers/azure/network_manager/network_port.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Azure::NetworkManager::NetworkPort < ::NetworkPort
+  def self.display_name(number = 1)
+    n_('Network Port (Microsoft Azure)', 'Network Ports (Microsoft Azure)', number)
+  end
 end


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836