### PR TITLE
Bump azure-armrest gem to 0.9.5

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.9.3"
+  s.add_dependency "azure-armrest", "~>0.9.5"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Pick up the changes to the azure-armrest gem that increase the speed of
Managed Disk Smartstate Analysis

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1508154

@djberg96 please review.

Needs backporting to Fine and Gaprindashvili