### PR TITLE
Treat securestring case insentive

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_template.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate < ::Orches
         :label         => key.titleize,
         :data_type     => val['type'],
         :default_value => val['defaultValue'],
-        :hidden        => val['type'] == 'securestring',
+        :hidden        => val['type'].casecmp('securestring').zero?,
         :required      => true
       )
 

--- a/spec/fixtures/orchestration_templates/azure_parameters.json
+++ b/spec/fixtures/orchestration_templates/azure_parameters.json
@@ -9,7 +9,7 @@
             }
         },
         "adminPassword": {
-            "type": "securestring",
+            "type": "secureString",
             "metadata": {
               "description": "Admin password"
             }

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_template_spec.rb
@@ -28,7 +28,7 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate do
       :name          => "adminPassword",
       :label         => "Admin Password",
       :description   => "Admin password",
-      :data_type     => "securestring",
+      :data_type     => "secureString",
       :default_value => nil,
       :hidden        => true,
       :required      => true,


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1543629

The dialog tool treats parameter type `securestring` as password field, but should accept the type key case insensitive.