### PR TITLE
Allowed cloud network without a zone should return everything

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -162,6 +162,7 @@ describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
     before do
       @az1 = FactoryGirl.create(:availability_zone, :ext_management_system => ems)
       @cn1 = FactoryGirl.create(:cloud_network, :ext_management_system => ems.network_manager)
+      @cn2 = FactoryGirl.create(:cloud_network, :ext_management_system => ems.network_manager)
       FactoryGirl.create(:cloud_subnet, :cloud_network => @cn1, :availability_zone => @az1)
       FactoryGirl.create(:cloud_subnet, :cloud_network => @cn1)
     end
@@ -184,9 +185,9 @@ describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
         expect(cns.keys).to match_array [@cn1.id]
       end
 
-      it "#allowed_cloud_networks without availability zone returns nothing" do
+      it "#allowed_cloud_networks without availability zone returns everything" do
         cns = workflow.allowed_cloud_networks
-        expect(cns.keys).to match_array []
+        expect(cns.keys).to match_array [@cn1.id, @cn2.id]
       end
     end
   end


### PR DESCRIPTION
This was originally merged erroneously because Travis run didn't complete all tests on https://github.com/ManageIQ/manageiq-providers-azure/pull/199. If it had, I think it would've failed due to the error this fixes.  It passed originally because the call to all_cloud_networks was wrong and got fixed here: https://github.com/ManageIQ/manageiq/pull/16824/files. Before the last PR got merged, this test would've been correct as the call erroneously returned nothing. Since the merge of https://github.com/ManageIQ/manageiq/pull/16824, the call for azure returns everything, and thus this test needs to change. 

Should return all, not none, due to https://github.com/d-m-u/manageiq/blob/59ba714ccb71b2eb3cdd46157587e85329af4f3b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb#L98. 