### PR TITLE
Handle possible race conditions for disks, events

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -210,6 +210,9 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
     rescue ::Azure::Armrest::RequestTimeoutException # Problem on Azure side
       _log.warn("Timeout attempting to collect metrics definitions for: #{target.name}/#{target.resource_group.name}. Skipping.")
       counters = []
+    rescue ::Azure::Armrest::NotFoundException # VM deleted
+      _log.warn("Could not find metrics definitions for: #{target.name}/#{target.resource_group.name}. Skipping.")
+      counters = []
     rescue Exception => err
       _log.error("Unhandled exception during counter collection: #{target.name}/#{target.resource_group.name}")
       _log.log_backtrace(err)

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -365,8 +365,15 @@ module ManageIQ::Providers
           disk_type     = 'managed'
           disk_location = disk.managed_disk.id
           managed_disk  = @managed_disks.find { |d| d.id.casecmp(disk_location).zero? }
-          disk_size     = managed_disk.properties.disk_size_gb.gigabytes
-          mode          = managed_disk.sku.name
+
+          if managed_disk
+            disk_size = managed_disk.properties.disk_size_gb.gigabytes
+            mode      = managed_disk.sku.name
+          else
+            _log.warn("Unable to find disk information for #{instance.name}/#{instance.resource_group}")
+            disk_size = nil
+            mode      = nil
+          end
         else
           disk_type     = 'unmanaged'
           disk_location = disk.try(:vhd).try(:uri)


### PR DESCRIPTION
This fixes race conditions where disk information, and metrics collection, could fail if an attempt is made to collect disk and/or metrics information after a VM is deleted.

In both cases, we simply log a warning and press on, as there is nothing else we can do.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1545519