### PR TITLE
Allow users to choose public or private IP when provisioning multiple VMs

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
@@ -27,7 +27,13 @@ class ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow < ManageIQ::Pr
   end
 
   def allowed_floating_ip_addresses(options = {})
-    super(options).merge(-1 => 'New')
+    num_vms_selected = dialog_field_visibility_service.number_of_vms_visibility_service.number_of_vms
+
+    if num_vms_selected > 1
+      {-1 => 'New'}
+    else
+      super(options).merge(-1 => 'New')
+    end
   end
 
   private
@@ -38,5 +44,9 @@ class ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow < ManageIQ::Pr
 
   def self.provider_model
     ManageIQ::Providers::Azure::CloudManager
+  end
+
+  def dialog_field_visibility_service
+    @dialog_field_visibility_service ||= ManageIQ::Providers::Azure::DialogFieldVisibilityService.new
   end
 end

--- a/app/services/manageiq/providers/azure/dialog_field_visibility_service.rb
+++ b/app/services/manageiq/providers/azure/dialog_field_visibility_service.rb
@@ -1,0 +1,19 @@
+class ManageIQ::Providers::Azure::DialogFieldVisibilityService < ::DialogFieldVisibilityService
+  attr_reader :number_of_vms_visibility_service
+
+  def initialize(
+    auto_placement_visibility_service = AutoPlacementVisibilityService.new,
+    number_of_vms_visibility_service = ManageIQ::Providers::Azure::NumberOfVmsVisibilityService.new,
+    service_template_fields_visibility_service = ServiceTemplateFieldsVisibilityService.new,
+    network_visibility_service = NetworkVisibilityService.new,
+    sysprep_auto_logon_visibility_service = SysprepAutoLogonVisibilityService.new,
+    retirement_visibility_service = RetirementVisibilityService.new,
+    customize_fields_visibility_service = CustomizeFieldsVisibilityService.new,
+    sysprep_custom_spec_visibility_service = SysprepCustomSpecVisibilityService.new,
+    request_type_visibility_service = RequestTypeVisibilityService.new,
+    pxe_iso_visibility_service = PxeIsoVisibilityService.new,
+    linked_clone_visibility_service = LinkedCloneVisibilityService.new
+  )
+    super
+  end
+end

--- a/app/services/manageiq/providers/azure/number_of_vms_visibility_service.rb
+++ b/app/services/manageiq/providers/azure/number_of_vms_visibility_service.rb
@@ -1,0 +1,18 @@
+class ManageIQ::Providers::Azure::NumberOfVmsVisibilityService < ::NumberOfVmsVisibilityService
+  def determine_visibility(number_of_vms, platform)
+    @number_of_vms = number_of_vms
+
+    hash = super
+
+    # For Azure we will show two options in this case - private and public
+    if @number_of_vms > 1
+      hash[:hide].delete(:floating_ip_address)
+    end
+
+    hash
+  end
+
+  def number_of_vms
+    @number_of_vms || 1
+  end
+end

--- a/lib/manageiq/providers/azure/engine.rb
+++ b/lib/manageiq/providers/azure/engine.rb
@@ -3,6 +3,7 @@ module ManageIQ
     module Azure
       class Engine < ::Rails::Engine
         isolate_namespace ManageIQ::Providers::Azure
+        config.autoload_paths << root.join('app', 'services').to_s
       end
     end
   end

--- a/spec/services/manageiq/providers/azure/dialog_field_visibility_service_spec.rb
+++ b/spec/services/manageiq/providers/azure/dialog_field_visibility_service_spec.rb
@@ -1,0 +1,20 @@
+describe ManageIQ::Providers::Azure::DialogFieldVisibilityService do
+  context "class information" do
+    it "is a subclass of DialogVisibilityService" do
+      expect(described_class.new).to be_kind_of(DialogFieldVisibilityService)
+    end
+  end
+
+  context "NumberOfVmsVisibilityService" do
+    subject { described_class.new }
+
+    it "has a reader method for number_of_vms_visibility_service" do
+      expect(subject).to respond_to(:number_of_vms_visibility_service)
+    end
+
+    it "defaults to an Azure::NumberOfVmsVisibilityService instance" do
+      expected_class = ManageIQ::Providers::Azure::NumberOfVmsVisibilityService
+      expect(subject.number_of_vms_visibility_service).to be_kind_of(expected_class)
+    end
+  end
+end

--- a/spec/services/manageiq/providers/azure/number_of_vms_visibility_service_spec.rb
+++ b/spec/services/manageiq/providers/azure/number_of_vms_visibility_service_spec.rb
@@ -1,0 +1,24 @@
+describe ManageIQ::Providers::Azure::NumberOfVmsVisibilityService do
+  context "class information" do
+    it "is a subclass of DialogVisibilityService" do
+      expect(described_class.new).to be_kind_of(NumberOfVmsVisibilityService)
+    end
+  end
+
+  context "NumberOfVmsVisibilityService" do
+    subject { described_class.new }
+
+    it "has a reader method for number_of_vms" do
+      expect(subject).to respond_to(:number_of_vms)
+    end
+
+    it "defaults to 1 for the number of vms" do
+      expect(described_class.new.number_of_vms).to eql(1)
+    end
+
+    it "returns the expected value for determine_visibility" do
+      expect(subject.determine_visibility(1, 'azure')).to be_kind_of(Hash)
+      expect(subject.determine_visibility(2, 'azure')[:hide]).to_not include(:floating_ip_addresses)
+    end
+  end
+end


### PR DESCRIPTION
When we introduced https://github.com/ManageIQ/manageiq-providers-azure/pull/172, we defaulted to a private IP for provisioning a single VM. This had the unintended side effect of making multi-vm provisioning private by default, with no way for the user to choose.

This PR addresses that by giving the users two choices - new or none - when selecting an IP during the provisioning process for multiple vm's.

Rather than making specialized PR's based on provider on the UI side, this PR uses custom service subclasses that allow us to govern the UI behavior without modifying any core code.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1531275

I have sanity checked this by provisioning two VM's with "none" selected, and two with "new" selected. The app behaved as expected, i.e. the vm's with "none" selected did not have a public IP attached, while those with "new" selected did.

~~WIP for now until I get some specs added.~~