### PR TITLE
Update azure-armrest to 0.9.6

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.9.5"
+  s.add_dependency "azure-armrest", "~>0.9.6"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Version 0.9.6 includes a patch for model generation.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1548153