### PR TITLE
Consolidate Azure refresh workers

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_worker.rb
@@ -1,3 +1,24 @@
 class ManageIQ::Providers::Azure::CloudManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
   require_nested :Runner
+
+  # overriding queue_name_for_ems so PerEmsWorkerMixin picks up *all* of the
+  # Azure-manager types from here.
+  # This way, the refresher for Azure's CloudManager will refresh *all*
+  # of the Azure inventory across all managers.
+  class << self
+    def queue_name_for_ems(ems)
+      return ems unless ems.kind_of?(ExtManagementSystem)
+      combined_managers(ems).collect(&:queue_name).sort
+    end
+
+    private
+
+    def combined_managers(ems)
+      [ems].concat(ems.child_managers)
+    end
+  end
+
+  # MiQ complains if this isn't defined
+  def queue_name_for_ems(ems)
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/refresher.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresher.rb
@@ -53,6 +53,22 @@ module ManageIQ::Providers::Azure
       EmsRefresh.queue_refresh(ems.network_manager)
     end
 
+    def preprocess_targets
+      # sort the EMSes to be refreshed with cloud managers before other EMSes.
+      # since @targets_by_ems_id is a hash, we have to insert the items into a new
+      # hash in the order we want them to appear.
+      sorted_ems_targets = {}
+      # pull out the IDs of cloud managers and reinsert them in a new hash first, to take advantage of preserved insertion order
+      cloud_manager_ids = @targets_by_ems_id.keys.select { |key| @ems_by_ems_id[key].kind_of? ManageIQ::Providers::Azure::CloudManager }
+      cloud_manager_ids.each { |ems_id| sorted_ems_targets[ems_id] = @targets_by_ems_id.delete(ems_id) }
+      # now that the cloud managers have been removed from @targets_by_ems_id, move the rest of the values
+      # over to the new hash and then replace @targets_by_ems_id.
+      @targets_by_ems_id.keys.each { |ems_id| sorted_ems_targets[ems_id] = @targets_by_ems_id.delete(ems_id) }
+      @targets_by_ems_id = sorted_ems_targets
+
+      super
+    end
+
     def post_process_refresh_classes
       [::Vm]
     end

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresh_worker_spec.rb
@@ -1,0 +1,26 @@
+describe ManageIQ::Providers::Azure::CloudManager::RefreshWorker do
+  context "EMS with children" do
+    let!(:network_manager) { FactoryGirl.create(:ems_network) }
+    let(:ems) do
+      FactoryGirl.create(:ems_cloud).tap do |ems|
+        network_manager.update_attributes(:parent_ems_id => ems.id)
+      end
+    end
+
+    it ".queue_name_for_ems" do
+      queue_name = described_class.queue_name_for_ems(ems)
+      expect(queue_name.count).to eq(2)
+      expect(queue_name.sort).to  eq(queue_name)
+    end
+  end
+
+  context "EMS with no children" do
+    let(:ems) { FactoryGirl.create(:ems_cloud) }
+
+    it ".queue_name_for_ems" do
+      queue_name = described_class.queue_name_for_ems(ems)
+      expect(queue_name.count).to eq(1)
+      expect(queue_name.first).to eq(ems.queue_name)
+    end
+  end
+end


### PR DESCRIPTION
Join all refresh worker queues together so it can be merged into one worker.

Related: https://github.com/ManageIQ/manageiq/pull/17076
Required by: https://github.com/ManageIQ/manageiq-providers-azure/pull/212
Related discussion: https://github.com/ManageIQ/manageiq/pull/16465, https://github.com/ManageIQ/manageiq-providers-openstack/pull/154

One of many requirements for: https://bugzilla.redhat.com/show_bug.cgi?id=1487602

@miq-bot add_label gaprindashvili/yes
cc @Ladas 