### PR TITLE
Update azure-armrest to 0.9.7

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.9.6"
+  s.add_dependency "azure-armrest", "~>0.9.7"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The 0.9.7 release adds support for `get_by_id` for template deployments and template deployment operations. We'll want this for the targeted refresh.