### PR TITLE
Fix case-sensitive events ems_ref parsing

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_target_parser.rb
@@ -64,7 +64,7 @@ class ManageIQ::Providers::Azure::CloudManager::EventTargetParser
 
   def transform_resource_id(association, resource_id)
     case association
-    when :network_ports, :security_groups, :load_balancers, :floating_ips, :cloud_networks, :resource_groups, :__unused
+    when :network_ports, :load_balancers, :resource_groups, :__unused
       fix_down_cased_resource_groups(resource_id)
     when :orchestration_stacks
       resource_id_for_stack_id(resource_id)
@@ -72,6 +72,12 @@ class ManageIQ::Providers::Azure::CloudManager::EventTargetParser
       resource_id_for_instance_id(resource_id)
     when :miq_templates
       resource_id.try(:downcase)
+    when :floating_ips
+      resource_id_for_floating_ips(resource_id)
+    when :cloud_networks
+      resource_id_for_cloud_networks(resource_id)
+    when :security_groups
+      resource_id_for_security_groups(resource_id)
     else
       resource_id
     end
@@ -111,6 +117,22 @@ class ManageIQ::Providers::Azure::CloudManager::EventTargetParser
                  resource_group.downcase,
                  "#{type.downcase}/#{sub_type.downcase}",
                  name)
+  end
+
+  def resource_id_for_cloud_networks(id)
+    id.gsub!("virtualnetworks", "virtualNetworks")
+    id = id.split("/subnets/").first
+    fix_down_cased_resource_groups(id)
+  end
+
+  def resource_id_for_floating_ips(id)
+    id.gsub!("publicIpAddresses", "publicIPAddresses")
+    fix_down_cased_resource_groups(id)
+  end
+
+  def resource_id_for_security_groups(id)
+    id = id.split("/securityRules/").first
+    fix_down_cased_resource_groups(id)
   end
 
   def resource_uid(*keys)

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_target_parser_spec.rb
@@ -55,29 +55,18 @@ describe ManageIQ::Providers::Azure::CloudManager::EventTargetParser do
 
   context "CloudNetwork events" do
     let(:klass) { :cloud_networks }
+    let(:expected_ems_ref) { "/subscriptions/#{@ems.subscription}/resourceGroups/#{resource_group}/providers/Microsoft.Network/virtualNetworks/test-vnet" }
+
+    it_behaves_like "parses_event", "virtualNetworks_delete_EndRequest"
+    it_behaves_like "parses_event", "virtualNetworks_write_EndRequest"
+    it_behaves_like "parses_event", "virtualNetworks_subnets_EndRequest"
 
     context do
-      let(:expected_ems_ref) { "/subscriptions/#{@ems.subscription}/resourceGroups/#{resource_group}/providers/Microsoft.Network/virtualNetworks/test-vnet" }
-
-      it_behaves_like "parses_event", "virtualNetworks_delete_EndRequest"
-      it_behaves_like "parses_event", "virtualNetworks_write_EndRequest"
-    end
-
-    context do
-      let(:expected_ems_ref) { "/subscriptions/#{@ems.subscription}/resourceGroups/#{resource_group}/providers/Microsoft.Network/virtualnetworks/test-vnet" }
       let(:event_variant) { :downcase }
 
       it_behaves_like "parses_event", "virtualnetworks_delete_EndRequest"
       it_behaves_like "parses_event", "virtualnetworks_write_EndRequest"
-    end
-
-    it_behaves_like "parses_event", "virtualNetworks_subnets_EndRequest" do
-      let(:expected_ems_ref) { "/subscriptions/#{@ems.subscription}/resourceGroups/#{resource_group}/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet" }
-    end
-
-    it_behaves_like "parses_event", "virtualnetworks_subnets_EndRequest" do
-      let(:expected_ems_ref) { "/subscriptions/#{@ems.subscription}/resourceGroups/#{resource_group}/providers/Microsoft.Network/virtualnetworks/test-vnet/subnets/test-vnet-subnet" }
-      let(:event_variant) { :downcase }
+      it_behaves_like "parses_event", "virtualnetworks_subnets_EndRequest"
     end
   end
 
@@ -87,9 +76,7 @@ describe ManageIQ::Providers::Azure::CloudManager::EventTargetParser do
 
     it_behaves_like "parses_event", "networkSecurityGroups_delete_EndRequest"
     it_behaves_like "parses_event", "networkSecurityGroups_write_EndRequest"
-    it_behaves_like "parses_event", "networkSecurityGroups_securityRules_EndRequest" do
-      let(:expected_ems_ref) { "/subscriptions/#{@ems.subscription}/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/test-nsg/securityRules/test-rule" }
-    end
+    it_behaves_like "parses_event", "networkSecurityGroups_securityRules_EndRequest"
   end
 
   context "LoadBalancer events" do
@@ -113,16 +100,12 @@ describe ManageIQ::Providers::Azure::CloudManager::EventTargetParser do
 
   context "FloatingIp events" do
     let(:klass) { :floating_ips }
+    let(:expected_ems_ref) { "/subscriptions/#{@ems.subscription}/resourceGroups/#{resource_group}/providers/Microsoft.Network/publicIPAddresses/test-ip" }
+
+    it_behaves_like "parses_event", "publicIPAddresses_delete_EndRequest"
+    it_behaves_like "parses_event", "publicIPAddresses_write_EndRequest"
 
     context do
-      let(:expected_ems_ref) { "/subscriptions/#{@ems.subscription}/resourceGroups/#{resource_group}/providers/Microsoft.Network/publicIPAddresses/test-ip" }
-
-      it_behaves_like "parses_event", "publicIPAddresses_delete_EndRequest"
-      it_behaves_like "parses_event", "publicIPAddresses_write_EndRequest"
-    end
-
-    context do
-      let(:expected_ems_ref) { "/subscriptions/#{@ems.subscription}/resourceGroups/#{resource_group}/providers/Microsoft.Network/publicIpAddresses/test-ip" }
       let(:event_variant) { :downcase }
 
       it_behaves_like "parses_event", "publicIpAddresses_delete_EndRequest"


### PR DESCRIPTION
Normalize `ems_ref` for:

- [x] `:floating_ips` (`publicIPAddresses` is correct)
- [x] `:cloud_networks` (`virtualNetworks` is correct, strip subnet related details)
- [x] `:security_groups` (remove security rules related parts, leave parent security group only)

Specs are consolidated, so despite different case of letters inside the event JSON, the `ems_ref` remains consistent.