### PR TITLE
Ignore api-version string in cassettes

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,12 @@ end
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::Azure::Engine.root, 'spec/vcr_cassettes')
+  config.default_cassette_options = {
+    :match_requests_on => [
+      :method,
+      VCR.request_matchers.uri_without_param('api-version')
+    ]
+  }
 end
 
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
Dealing with api-version incompatibilities in cassettes between major releases has proven to be a royal pain. As a general rule we don't care about the api-version in the cassettes, and any behavioral changes that might happen would be tested on the backend anyway via the refresher/collection code.

By ignoring the api-version we can more easily backport PR's that include updated VCR cassettes.

For some local testing, I tried mangling the api-version dates. The specs still passed. I also deliberately mangled some other parts of the request, and it failed as expected.