### PR TITLE
Ignore deployment events

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -59,10 +59,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   end
 
   def self.default_blacklisted_event_names
-    %w(
-      storageAccounts_listKeys_BeginRequest
-      storageAccounts_listKeys_EndRequest
-    )
+    Settings.ems.ems_azure.blacklisted_event_names
   end
 
   def self.api_allowed_attributes

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,11 @@
       :template_deployment: 2017-08-01
       :virtual_machine: 2017-12-01
       :virtual_network: 2017-11-01
-    :blacklisted_event_names: []
+    :blacklisted_event_names:
+      - storageAccounts_listKeys_BeginRequest
+      - storageAccounts_listKeys_EndRequest
+      - deployments_exportTemplate_BeginRequest
+      - deployments_exportTemplate_EndRequest
     :event_handling:
       :event_groups:
         :addition:

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -17,6 +17,10 @@ describe ManageIQ::Providers::Azure::CloudManager do
     expect(described_class.description).to eq('Azure')
   end
 
+  it ".default_blacklisted_event_names" do
+    expect(described_class.default_blacklisted_event_names).to eq(Settings.ems.ems_azure.blacklisted_event_names)
+  end
+
   it "does not create orphaned network_manager" do
     # When the cloud_manager is destroyed during a refresh the there will still be an instance
     # of the cloud_manager in the refresh worker. After the refresh we will try to save the cloud_manager


### PR DESCRIPTION
No action needs to be executed when the events `deployments_exportTemplate_BeginRequest` and `deployments_exportTemplate_EndRequest` are received, so we should blacklist them.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1561646

~~WIP for now as it doesn't seem to actually be working.~~

Also addresses the fact that the settings file was being ignored, as the ignored events were hard coded into the cloud manager.