### PR TITLE
Change saver_strategy value to String

### DIFF
--- a/app/models/manageiq/providers/azure/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory_collection_default/cloud_manager.rb
@@ -63,7 +63,7 @@ class ManageIQ::Providers::Azure::InventoryCollectionDefault::CloudManager < Man
     def orchestration_stacks(extra_attributes = {})
       attributes = {
         :model_class    => ::ManageIQ::Providers::Azure::CloudManager::OrchestrationStack,
-        :saver_strategy => :default # TODO(lsmola) can't batch unless we do smart batching
+        :saver_strategy => "default" # TODO(lsmola) can't batch unless we do smart batching
       }
 
       super(attributes.merge!(extra_attributes))

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,14 +60,14 @@
     # Not fetching resources and templates of deployments unless deployment changed [Graph refresh only]
     :enabled_deployments_caching: true
     :inventory_collections:
-      # Strategy for saving, another allowed is :batch, doing batch SQL queries [Graph refresh only]
-      :saver_strategy: :default
+      # Strategy for saving, another allowed is batch, doing batch SQL queries [Graph refresh only]
+      :saver_strategy: default
   :azure_network:
     # Same options as in :azure, applied for a network manager
     :inventory_object_refresh: false
     :allow_targeted_refresh: true
     :inventory_collections:
-      :saver_strategy: :default
+      :saver_strategy: default
 :http_proxy:
   :azure:
     :host:

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -6,13 +6,13 @@ module AzureRefresherSpecCommon
       :get_private_images       => true,
       :inventory_object_refresh => true,
       :inventory_collections    => {
-        :saver_strategy => :default,
+        :saver_strategy => "default",
       },
     }, {
       :get_private_images       => true,
       :inventory_object_refresh => true,
       :inventory_collections    => {
-        :saver_strategy => :batch,
+        :saver_strategy => "batch",
         :use_ar_object  => false,
       },
     }

--- a/spec/models/manageiq/providers/azure/cloud_manager/deployments_caching_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/deployments_caching_spec.rb
@@ -10,14 +10,14 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       :get_private_images          => true,
       :inventory_object_refresh    => true,
       :inventory_collections       => {
-        :saver_strategy => :default,
+        :saver_strategy => "default",
       },
     }, {
       :enabled_deployments_caching => false,
       :get_private_images          => true,
       :inventory_object_refresh    => true,
       :inventory_collections       => {
-        :saver_strategy => :default,
+        :saver_strategy => "default",
       },
     }
   ].each do |refresh_settings|


### PR DESCRIPTION
Symbols in configuration values are problematic because Symbols do not
roundtrip through JSON.  Since the API now exposes Settings, it's not
possible to set Symbols as values.  The saver_strategy was fixed in
https://github.com/ManageIQ/manageiq/pull/17168 to support String
values, and the next step is to remove all Symbols from the Settings.

https://github.com/ManageIQ/manageiq/issues/17201
https://bugzilla.redhat.com/show_bug.cgi?id=1558031

@Ladas Please review
