### PR TITLE
Convert api-version strings to actual strings

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -83,7 +83,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
       config = raw_connect(clientid, clientkey, azure_tenant_id, subscription)
 
       azure_res = ::Azure::Armrest::ResourceService.new(config)
-      azure_res.api_version = Settings.ems.ems_azure.api_versions.resource.to_s
+      azure_res.api_version = Settings.ems.ems_azure.api_versions.resource
 
       azure_res.list_locations.each do |region|
         next if known_ems_regions.include?(region.name)

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -110,85 +110,85 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
 
   def availability_set_service(config)
     ::Azure::Armrest::AvailabilitySetService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.availability_set.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.availability_set
     end
   end
 
   def ip_address_service(config)
     ::Azure::Armrest::Network::IpAddressService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.ip_address.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.ip_address
     end
   end
 
   def load_balancer_service(config)
     ::Azure::Armrest::Network::LoadBalancerService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.load_balancer.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.load_balancer
     end
   end
 
   def managed_image_service(config)
     ::Azure::Armrest::Storage::ImageService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.managed_image.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.managed_image
     end
   end
 
   def virtual_machine_image_service(config, options = {})
     ::Azure::Armrest::VirtualMachineImageService.new(config, options).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.managed_image.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.managed_image
     end
   end
 
   def network_interface_service(config)
     ::Azure::Armrest::Network::NetworkInterfaceService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.network_interface.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.network_interface
     end
   end
 
   def network_security_group_service(config)
     ::Azure::Armrest::Network::NetworkSecurityGroupService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.network_security_group.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.network_security_group
     end
   end
 
   def resource_group_service(config)
     ::Azure::Armrest::ResourceGroupService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.resource_group.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.resource_group
     end
   end
 
   def route_table_service(config)
     ::Azure::Armrest::Network::RouteTableService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.route_table.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.route_table
     end
   end
 
   def template_deployment_service(config)
     ::Azure::Armrest::TemplateDeploymentService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.template_deployment.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.template_deployment
     end
   end
 
   def storage_disk_service(config)
     ::Azure::Armrest::Storage::DiskService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.storage_disk.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.storage_disk
     end
   end
 
   def storage_account_service(config)
     ::Azure::Armrest::StorageAccountService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.storage_account.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.storage_account
     end
   end
 
   def virtual_machine_service(config)
     ::Azure::Armrest::VirtualMachineService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.virtual_machine.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.virtual_machine
     end
   end
 
   def virtual_network_service(config)
     ::Azure::Armrest::Network::VirtualNetworkService.new(config).tap do |service|
-      service.api_version = Settings.ems.ems_azure.api_versions.virtual_network.to_s
+      service.api_version = Settings.ems.ems_azure.api_versions.virtual_network
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,20 +2,20 @@
 :ems:
   :ems_azure:
     :api_versions:
-      :availability_set: 2017-12-01
-      :ip_address: 2017-11-01
-      :load_balancer: 2017-11-01
-      :managed_image: 2017-12-01
-      :network_interface: 2017-11-01
-      :network_security_group: 2017-11-01
-      :resource: 2017-08-01
-      :resource_group: 2017-08-01
-      :route_table: 2018-03-01
-      :storage_account: 2017-10-01
-      :storage_disk: 2017-03-30
-      :template_deployment: 2017-08-01
-      :virtual_machine: 2017-12-01
-      :virtual_network: 2017-11-01
+      :availability_set: "2017-12-01"
+      :ip_address: "2017-11-01"
+      :load_balancer: "2017-11-01"
+      :managed_image: "2017-12-01"
+      :network_interface: "2017-11-01"
+      :network_security_group: "2017-11-01"
+      :resource: "2017-08-01"
+      :resource_group: "2017-08-01"
+      :route_table: "2018-03-01"
+      :storage_account: "2017-10-01"
+      :storage_disk: "2017-03-30"
+      :template_deployment: "2017-08-01"
+      :virtual_machine: "2017-12-01"
+      :virtual_network: "2017-11-01"
     :blacklisted_event_names:
       - storageAccounts_listKeys_BeginRequest
       - storageAccounts_listKeys_EndRequest


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/issues/17201 and https://github.com/ManageIQ/manageiq-providers-azure/pull/235. Eliminates lots of unnecessary `to_s` calls as well.