### PR TITLE
Ensure image name is clean

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -662,11 +662,6 @@ module ManageIQ::Providers
         return uid, new_result
       end
 
-      def build_image_name(image)
-        # Strip the .vhd and Azure GUID extension, but retain path and base name.
-        File.join(File.dirname(image.name), File.basename(File.basename(image.name, '.*'), '.*'))
-      end
-
       def build_image_description(image)
         # Description is a concatenation of resource group and storage account
         "#{image.storage_account.resource_group}/#{image.storage_account.name}"

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -449,7 +449,8 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
 
   def build_image_name(image)
     # Strip the .vhd and Azure GUID extension, but retain path and base name.
-    File.join(File.dirname(image.name), File.basename(File.basename(image.name, '.*'), '.*'))
+    path = File.join(File.dirname(image.name), File.basename(File.basename(image.name, '.*'), '.*'))
+    Pathname.new(path).cleanpath.to_s
   end
 
   def build_image_description(image)

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -1,6 +1,8 @@
 # TODO: Separate collection from parsing (perhaps collecting in parallel a la RHEVM)
 
 class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Providers::Azure::Inventory::Parser
+  include ManageIQ::Providers::Azure::RefreshHelperMethods
+
   def parse
     log_header = "Collecting data for EMS : [#{collector.manager.name}] id: [#{collector.manager.id}]"
 
@@ -445,12 +447,6 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
     else
       resource.properties.status_message.to_s
     end
-  end
-
-  def build_image_name(image)
-    # Strip the .vhd and Azure GUID extension, but retain path and base name.
-    path = File.join(File.dirname(image.name), File.basename(File.basename(image.name, '.*'), '.*'))
-    Pathname.new(path).cleanpath.to_s
   end
 
   def build_image_description(image)

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -34,6 +34,13 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     MiqProcess.processInfo[:proportional_set_size].to_f / 1.megabyte
   end
 
+  # Strip the .vhd and Azure GUID extension, but retain path and base name.
+  #
+  def build_image_name(image)
+    path = File.join(File.dirname(image.name), File.basename(File.basename(image.name, '.*'), '.*'))
+    Pathname.new(path).cleanpath.to_s
+  end
+
   def process_collection(collection, key, store_in_data = true)
     @data[key] ||= [] if store_in_data
 

--- a/spec/factories/image.rb
+++ b/spec/factories/image.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :azure_image, :class => 'ManageIQ::Providers::Azure::CloudManager::Template'
+end

--- a/spec/models/manageiq/providers/azure/refresh_helper_methods_spec.rb
+++ b/spec/models/manageiq/providers/azure/refresh_helper_methods_spec.rb
@@ -22,6 +22,18 @@ describe ManageIQ::Providers::Azure::RefreshHelperMethods do
     end
   end
 
+  context "build_image_name" do
+    it "removes ./ from image names" do
+      image = FactoryGirl.create(:azure_image, :name => './foo', :location => 'westus', :vendor => 'azure')
+      expect(@ems_azure.build_image_name(image)).to eql('foo')
+    end
+
+    it "does not affect images that do not have a ./ in them" do
+      image = FactoryGirl.create(:azure_image, :name => 'foo', :location => 'westus', :vendor => 'azure')
+      expect(@ems_azure.build_image_name(image)).to eql('foo')
+    end
+  end
+
   context "gather_data_for_region" do
     it "requires a service name" do
       expect { @ems_azure.gather_data_for_this_region }.to raise_error(ArgumentError)


### PR DESCRIPTION
The `build_image_name` method will create a leading "./" if the dirname is relative. This is because `File.dirname("foo")` returns "." on relative path names.

~~WIP for now until I can see if there's a nicer way without involving Pathname.~~

I didn't see a better way, so Pathname it is.

See also https://github.com/ManageIQ/manageiq-schema/pull/198

