### PR TITLE
Update azure-armrest gem to 0.9.10

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.9.7"
+  s.add_dependency "azure-armrest", "~>0.9.10"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This upgrades the azure-armrest gem from 0.9.7 to 0.9.10. Below is a summary of the changes. The most relevant being the fix for `TemplateDeploymentService#create`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1568009

```
= 0.9.10 - 17-Apr-2018
* Fixed a bug in the TemplateDeploymentService#create method where it would
  transform template keys that shouldn't be transformed. Individual subclasses
  can now control this behavior as needed.
* Updated the addressable dependency to 2.5.0.
* Updated the docs for the VirtualMachineExtension#list method. That method
  appears to be working again. It was previously broken on the Azure side.

= 0.9.9 - 6-Apr-2018
* Changed the default endpoint used for fetching the initial authorization
  token. It now uses the AD resource ID instead of the resource manager URL.

= 0.9.8 - 14-mar-2018
* Performance of the VirtualMachineImageService#list_all method has been
  dramatically improved.
* Added the StorageAccountService#get_by_url method.
* Fixed an error message in the StorageAccountService#list_private_images method.
* Added an error check for invalid ID strings in the
  ResourceGroupBasedService#get_by_id method.
* Minor doc updates.
```