### PR TITLE
Forward slash all the things

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_target_parser.rb
@@ -113,7 +113,7 @@ class ManageIQ::Providers::Azure::CloudManager::EventTargetParser
   def resource_id_for_instance_id(id)
     return nil unless id
     _, _, guid, _, resource_group, _, type, sub_type, name = id.split("/")
-    File.join(guid, resource_group.downcase, "#{type.downcase}/#{sub_type.downcase}", name)
+    File.join(guid, resource_group.downcase, type.downcase, sub_type.downcase, name)
   end
 
   def resource_id_for_cloud_networks(id)

--- a/app/models/manageiq/providers/azure/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_target_parser.rb
@@ -113,10 +113,7 @@ class ManageIQ::Providers::Azure::CloudManager::EventTargetParser
   def resource_id_for_instance_id(id)
     return nil unless id
     _, _, guid, _, resource_group, _, type, sub_type, name = id.split("/")
-    resource_uid(guid,
-                 resource_group.downcase,
-                 "#{type.downcase}/#{sub_type.downcase}",
-                 name)
+    File.join(guid, resource_group.downcase, "#{type.downcase}/#{sub_type.downcase}", name)
   end
 
   def resource_id_for_cloud_networks(id)
@@ -133,10 +130,6 @@ class ManageIQ::Providers::Azure::CloudManager::EventTargetParser
   def resource_id_for_security_groups(id)
     id = id.split("/securityRules/").first
     fix_down_cased_resource_groups(id)
-  end
-
-  def resource_uid(*keys)
-    keys.join('\\')
   end
 
   def standard_uid(*keys)

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -10,7 +10,7 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
   end
 
   def find_destination_in_vmdb(vm_uid_hash)
-    ems_ref = vm_uid_hash.values.join("\\")
+    ems_ref = vm_uid_hash.values.join("/")
     ManageIQ::Providers::Azure::CloudManager::Vm.find_by("lower(ems_ref) = ?", ems_ref.downcase)
   end
 
@@ -122,11 +122,11 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
   end
 
   def storage_account_resource_group
-    source.description.split("\\").first
+    source.description.split("/").first
   end
 
   def storage_account_name
-    source.description.split("\\")[1]
+    source.description.split("/")[1]
   end
 
   def associated_nic

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -598,7 +598,7 @@ module ManageIQ::Providers
           :uid_ems            => uid,
           :ems_ref            => uid,
           :name               => image.name,
-          :description        => "#{image.resource_group}\\#{image.name}",
+          :description        => "#{image.resource_group}/#{image.name}",
           :location           => @ems.provider_region,
           :vendor             => 'azure',
           :raw_power_state    => 'never',
@@ -669,7 +669,7 @@ module ManageIQ::Providers
 
       def build_image_description(image)
         # Description is a concatenation of resource group and storage account
-        "#{image.storage_account.resource_group}\\#{image.storage_account.name}"
+        "#{image.storage_account.resource_group}/#{image.storage_account.name}"
       end
 
       # Remap from children to parent

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -255,7 +255,7 @@ module ManageIQ::Providers
       end
 
       def parse_instance(instance)
-        uid = resource_uid(@subscription_id,
+        uid = File.join(@subscription_id,
                            instance.resource_group.downcase,
                            instance.type.downcase,
                            instance.name)
@@ -418,7 +418,7 @@ module ManageIQ::Providers
 
       def parse_stack(deployment)
         name = deployment.name
-        uid = resource_uid(@subscription_id,
+        uid = File.join(@subscription_id,
                            deployment.resource_group.downcase,
                            TYPE_DEPLOYMENT,
                            name)
@@ -503,7 +503,7 @@ module ManageIQ::Providers
         stack_id = deployment.id
         get_stack_parameters(stack_id, raw_parameters)
         raw_parameters.collect do |param_key, _val|
-          @data_index.fetch_path(:orchestration_stack_parameters, resource_uid(stack_id, param_key))
+          @data_index.fetch_path(:orchestration_stack_parameters, File.join(stack_id, param_key))
         end
       end
 
@@ -514,14 +514,14 @@ module ManageIQ::Providers
         stack_id = deployment.id
         get_stack_outputs(stack_id, raw_outputs)
         raw_outputs.collect do |output_key, _val|
-          @data_index.fetch_path(:orchestration_stack_outputs, resource_uid(stack_id, output_key))
+          @data_index.fetch_path(:orchestration_stack_outputs, File.join(stack_id, output_key))
         end
       end
 
       def stack_resources(deployment)
         group = deployment.resource_group
         name = deployment.name
-        stack_uid = resource_uid(@subscription_id, group.downcase, TYPE_DEPLOYMENT, name)
+        stack_uid = File.join(@subscription_id, group.downcase, TYPE_DEPLOYMENT, name)
 
         raw_resources = get_stack_resources(name, group)
 
@@ -529,7 +529,7 @@ module ManageIQ::Providers
         resources = raw_resources.collect do |resource|
           resource_type = resource.properties.target_resource.resource_type
           resource_name = resource.properties.target_resource.resource_name
-          uid = resource_uid(@subscription_id, group.downcase, resource_type.downcase, resource_name)
+          uid = File.join(@subscription_id, group.downcase, resource_type.downcase, resource_name)
           @resource_to_stack[uid] = stack_uid
           child_stacks << uid if resource_type.downcase == TYPE_DEPLOYMENT
           @data_index.fetch_path(:orchestration_stack_resources, uid)
@@ -550,7 +550,7 @@ module ManageIQ::Providers
       end
 
       def parse_stack_parameter(param_key, param_obj, stack_id)
-        uid = resource_uid(stack_id, param_key)
+        uid = File.join(stack_id, param_key)
         new_result = {
           :ems_ref => uid,
           :name    => param_key,
@@ -560,7 +560,7 @@ module ManageIQ::Providers
       end
 
       def parse_stack_output(output_key, output_obj, stack_id)
-        uid = resource_uid(stack_id, output_key)
+        uid = File.join(stack_id, output_key)
         new_result = {
           :ems_ref     => uid,
           :key         => output_key,
@@ -583,7 +583,7 @@ module ManageIQ::Providers
           :resource_status_reason => status_message || status_code,
           :last_updated           => resource.properties.timestamp
         }
-        uid = resource_uid(@subscription_id, group.downcase, new_result[:resource_category].downcase, new_result[:name])
+        uid = File.join(@subscription_id, group.downcase, new_result[:resource_category].downcase, new_result[:name])
         return uid, new_result
       end
 

--- a/app/models/manageiq/providers/azure/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/azure/event_catcher_mixin.rb
@@ -30,6 +30,6 @@ module ManageIQ::Providers::Azure::EventCatcherMixin
     object_class,
     object_name = event["resourceId"].split("/")
 
-    [subscription_id, resource_group.downcase, "#{provider.downcase}\/#{object_class.downcase}", object_name].join("\\")
+    [subscription_id, resource_group.downcase, provider.downcase, object_class.downcase, object_name].join("/")
   end
 end

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -131,7 +131,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
                          else
                            collect_inventory_targeted(:instances) do
                              Parallel.map(refs, :in_threads => thread_limit) do |ems_ref|
-                               _subscription_id, group, _provider, _service, name = ems_ref.tr("\\", '/').split('/')
+                               _subscription_id, group, _provider, _service, name = ems_ref.split('/')
                                safe_targeted_request { @vmm.get(name, group) }
                              end
                            end

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -599,6 +599,6 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
     # the id string like this is suboptimal
     return nil unless id
     _, _, guid, _, resource_group, _, type, sub_type, name = id.split("/")
-    File.join(guid, resource_group.downcase, "#{type.downcase}/#{sub_type.downcase}", name)
+    File.join(guid, resource_group.downcase, type.downcase, sub_type.downcase, name)
   end
 end

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -121,7 +121,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
     @instances_cache ||= if refs.size > record_limit
                            set = Set.new(refs)
                            collect_inventory(:instances) { gather_data_for_this_region(@vmm) }.select do |instance|
-                             uid = resource_uid(subscription_id,
+                             uid = File.join(subscription_id,
                                                 instance.resource_group.downcase,
                                                 instance.type.downcase,
                                                 instance.name)
@@ -594,19 +594,11 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
     target.add_target(:association => association, :manager_ref => {:ems_ref => ems_ref})
   end
 
-  # Compose an id string combining some existing keys
-  def resource_uid(*keys)
-    keys.join('\\')
-  end
-
   def resource_id_for_instance_id(id)
     # TODO(lsmola) we really need to get rid of the building our own emf_ref, it makes crosslinking impossible, parsing
     # the id string like this is suboptimal
     return nil unless id
     _, _, guid, _, resource_group, _, type, sub_type, name = id.split("/")
-    resource_uid(guid,
-                 resource_group.downcase,
-                 "#{type.downcase}/#{sub_type.downcase}",
-                 name)
+    File.join(guid, resource_group.downcase, "#{type.downcase}/#{sub_type.downcase}", name)
   end
 end

--- a/app/models/manageiq/providers/azure/inventory/parser.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser.rb
@@ -5,9 +5,4 @@ class ManageIQ::Providers::Azure::Inventory::Parser < ManagerRefresh::Inventory:
   include Vmdb::Logging
 
   TYPE_DEPLOYMENT = "microsoft.resources/deployments".freeze
-
-  # Compose an id string combining some existing keys
-  def resource_uid(*keys)
-    keys.join('\\')
-  end
 end

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -353,7 +353,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
         :uid_ems            => uid,
         :ems_ref            => uid,
         :name               => image.name,
-        :description        => "#{image.resource_group}\\#{image.name}",
+        :description        => "#{image.resource_group}/#{image.name}",
         :location           => collector.manager.provider_region,
         :vendor             => 'azure',
         :raw_power_state    => 'never',
@@ -451,6 +451,6 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
 
   def build_image_description(image)
     # Description is a concatenation of resource group and storage account
-    "#{image.storage_account.resource_group}\\#{image.storage_account.name}"
+    "#{image.storage_account.resource_group}/#{image.storage_account.name}"
   end
 end

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -60,7 +60,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
 
   def instances
     collector.instances.each do |instance|
-      uid = resource_uid(collector.subscription_id,
+      uid = File.join(collector.subscription_id,
                          instance.resource_group.downcase,
                          instance.type.downcase,
                          instance.name)
@@ -270,7 +270,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
     return [] if raw_parameters.blank?
 
     raw_parameters.each do |param_key, param_obj|
-      uid = resource_uid(deployment.id, param_key)
+      uid = File.join(deployment.id, param_key)
       persister.orchestration_stacks_parameters.build(
         :stack   => persister_orchestration_stack,
         :ems_ref => uid,
@@ -285,7 +285,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
     return [] if raw_outputs.blank?
 
     raw_outputs.each do |output_key, output_obj|
-      uid = resource_uid(deployment.id, output_key)
+      uid = File.join(deployment.id, output_key)
       persister.orchestration_stacks_outputs.build(
         :stack       => persister_orchestration_stack,
         :ems_ref     => uid,

--- a/app/models/manageiq/providers/azure/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/network_manager.rb
@@ -351,7 +351,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::NetworkManager < ManageIQ::
     # the id string like this is suboptimal
     return nil unless id
     _, _, guid, _, resource_group, _, type, sub_type, name = id.split("/")
-    resource_uid(guid,
+    File.join(guid,
                  resource_group.downcase,
                  "#{type.downcase}/#{sub_type.downcase}",
                  name)

--- a/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
@@ -61,7 +61,7 @@ class ManageIQ::Providers::Azure::NetworkManager::RefreshParser
     # the id string like this is suboptimal
     return nil unless id
     _, _, guid, _, resource_group, _, type, sub_type, name = id.split("/")
-    resource_uid(guid,
+    File.join(guid,
                  resource_group.downcase,
                  "#{type.downcase}/#{sub_type.downcase}",
                  name)

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -46,11 +46,6 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     end
   end
 
-  # Compose an id string combining some existing keys
-  def resource_uid(*keys)
-    keys.join('\\')
-  end
-
   # For those resources without a location, default to the location of
   # their resource group.
   #

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -422,7 +422,7 @@ module AzureRefresherSpecCommon
     vm = ManageIQ::Providers::Azure::CloudManager::Vm.where(
       :name => @device_name, :raw_power_state => "VM running"
     ).first
-    vm_resource_id = "#{@ems.subscription}\\#{@resource_group}\\microsoft.compute/virtualmachines\\#{@device_name}"
+    vm_resource_id = "#{@ems.subscription}/#{@resource_group}/microsoft.compute/virtualmachines/#{@device_name}"
 
     expect(vm).to have_attributes(
       :template              => false,
@@ -587,7 +587,7 @@ module AzureRefresherSpecCommon
 
   def assert_specific_vm_powered_off_attributes(v)
     name = 'miqazure-centos1'
-    vm_resource_id = "#{@ems.subscription}\\#{@resource_group}\\microsoft.compute/virtualmachines\\#{name}"
+    vm_resource_id = "#{@ems.subscription}/#{@resource_group}/microsoft.compute/virtualmachines/#{name}"
 
     expect(v).to have_attributes(
       :template              => false,
@@ -728,7 +728,7 @@ module AzureRefresherSpecCommon
       :value   => "deploy1admin",
       :ems_ref => "/subscriptions/#{@ems.subscription}/resourceGroups"\
                       "/miq-azure-test1/providers/Microsoft.Resources"\
-                      "/deployments/spec-nested-deployment-dont-delete\\adminUsername"
+                      "/deployments/spec-nested-deployment-dont-delete/adminUsername"
     )
   end
 
@@ -759,7 +759,7 @@ module AzureRefresherSpecCommon
       :description => "siteUri",
       :ems_ref     => "/subscriptions/#{@ems.subscription}/resourceGroups"\
     "/miq-azure-test1/providers/Microsoft.Resources"\
-    "/deployments/spec-deployment-dont-delete\\siteUri"
+    "/deployments/spec-deployment-dont-delete/siteUri"
     )
   end
 
@@ -975,12 +975,12 @@ module AzureRefresherSpecCommon
   end
 
   def lbs_vms_targets
-    vm_resource_id1 = "#{@ems.subscription}\\miq-azure-test1\\microsoft.compute/virtualmachines\\rspec-lb-a"
+    vm_resource_id1 = "#{@ems.subscription}/miq-azure-test1/microsoft.compute/virtualmachines/rspec-lb-a"
     vm_target1      = ManagerRefresh::Target.new(:manager     => @ems,
                                                  :association => :vms,
                                                  :manager_ref => {:ems_ref => vm_resource_id1})
 
-    vm_resource_id2 = "#{@ems.subscription}\\miq-azure-test1\\microsoft.compute/virtualmachines\\rspec-lb-b"
+    vm_resource_id2 = "#{@ems.subscription}/miq-azure-test1/microsoft.compute/virtualmachines/rspec-lb-b"
     vm_target2      = ManagerRefresh::Target.new(:manager     => @ems,
                                                  :association => :vms,
                                                  :manager_ref => {:ems_ref => vm_resource_id2})
@@ -988,7 +988,7 @@ module AzureRefresherSpecCommon
   end
 
   def vm_powered_on_target
-    vm_resource_id = "#{@ems.subscription}\\#{@resource_group}\\microsoft.compute/virtualmachines\\#{@device_name}"
+    vm_resource_id = "#{@ems.subscription}/#{@resource_group}/microsoft.compute/virtualmachines/#{@device_name}"
 
     ManagerRefresh::Target.new(:manager     => @ems,
                                :association => :vms,
@@ -996,7 +996,7 @@ module AzureRefresherSpecCommon
   end
 
   def vm_powered_off_target
-    vm_resource_id = "#{@ems.subscription}\\#{@resource_group}\\microsoft.compute/virtualmachines\\#{@vm_powered_off}"
+    vm_resource_id = "#{@ems.subscription}/#{@resource_group}/microsoft.compute/virtualmachines/#{@vm_powered_off}"
 
     ManagerRefresh::Target.new(:manager     => @ems,
                                :association => :vms,
@@ -1004,7 +1004,7 @@ module AzureRefresherSpecCommon
   end
 
   def vm_with_managed_disk_target
-    vm_resource_id = "#{@ems.subscription}\\#{@resource_group_managed_vm}\\microsoft.compute/virtualmachines\\#{@managed_vm}"
+    vm_resource_id = "#{@ems.subscription}/#{@resource_group_managed_vm}/microsoft.compute/virtualmachines/#{@managed_vm}"
 
     ManagerRefresh::Target.new(:manager     => @ems,
                                :association => :vms,
@@ -1012,7 +1012,7 @@ module AzureRefresherSpecCommon
   end
 
   def non_existent_vm_target
-    vm_resource_id = "#{@ems.subscription}\\#{@resource_group_managed_vm}\\microsoft.compute/virtualmachines\\non_existent_vm_that_does_not_exist"
+    vm_resource_id = "#{@ems.subscription}/#{@resource_group_managed_vm}/microsoft.compute/virtualmachines/non_existent_vm_that_does_not_exist"
 
     ManagerRefresh::Target.new(:manager     => @ems,
                                :association => :vms,
@@ -1036,14 +1036,14 @@ module AzureRefresherSpecCommon
   end
 
   def child_orchestration_stack_vm_target
-    vm_resource_id = "#{@ems.subscription}\\miq-azure-test1\\microsoft.compute/virtualmachines\\spec0deply1vm0"
+    vm_resource_id = "#{@ems.subscription}/miq-azure-test1/microsoft.compute/virtualmachines/spec0deply1vm0"
     ManagerRefresh::Target.new(:manager     => @ems,
                                :association => :vms,
                                :manager_ref => {:ems_ref => vm_resource_id})
   end
 
   def child_orchestration_stack_vm_target2
-    vm_resource_id2 = "#{@ems.subscription}\\miq-azure-test1\\microsoft.compute/virtualmachines\\spec0deply1vm1"
+    vm_resource_id2 = "#{@ems.subscription}/miq-azure-test1/microsoft.compute/virtualmachines/spec0deply1vm1"
     ManagerRefresh::Target.new(:manager     => @ems,
                                :association => :vms,
                                :manager_ref => {:ems_ref => vm_resource_id2})

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_catcher/runner_spec.rb
@@ -20,7 +20,7 @@ describe ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner do
       end
 
       it "vm ref" do
-        expect(catcher.parse_vm_ref(event)).to eq "12345\\rg1\\microsoft.compute/virtualmachines\\TestVm"
+        expect(catcher.parse_vm_ref(event)).to eq "12345/rg1/microsoft.compute/virtualmachines/TestVm"
       end
     end
   end

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_parser_spec.rb
@@ -23,7 +23,7 @@ describe ManageIQ::Providers::Azure::CloudManager::EventParser do
         :ems_id     => nil,
         :event_type => 'virtualMachines_deallocate_BeginRequest',
         :full_data  => event,
-        :vm_ems_ref => "xyz\\bar\\microsoft.compute/virtualmachines\\another_vm"
+        :vm_ems_ref => "xyz/bar/microsoft.compute/virtualmachines/another_vm"
       )
     end
 
@@ -38,7 +38,7 @@ describe ManageIQ::Providers::Azure::CloudManager::EventParser do
         :ems_id     => nil,
         :event_type => 'New Recommendation',
         :full_data  => event,
-        :vm_ems_ref => "xyz\\foo\\microsoft.compute/virtualmachines\\my_vm1"
+        :vm_ems_ref => "xyz/foo/microsoft.compute/virtualmachines/my_vm1"
       )
     end
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_target_parser_spec.rb
@@ -34,7 +34,7 @@ describe ManageIQ::Providers::Azure::CloudManager::EventTargetParser do
 
   context "VM events" do
     let(:klass) { :vms }
-    let(:expected_ems_ref) { "#{@ems.subscription}\\#{resource_group}\\microsoft.compute/virtualmachines\\test-vm" }
+    let(:expected_ems_ref) { "#{@ems.subscription}/#{resource_group}/microsoft.compute/virtualmachines/test-vm" }
 
     it_behaves_like "parses_event", "virtualMachines_deallocate_EndRequest"
     it_behaves_like "parses_event", "virtualMachines_delete_EndRequest"
@@ -47,7 +47,7 @@ describe ManageIQ::Providers::Azure::CloudManager::EventTargetParser do
 
   context "VM lock events" do
     let(:klass) { :vms }
-    let(:expected_ems_ref) { "#{@ems.subscription}\\#{resource_group}\\microsoft.authorization/locks\\test-lock" }
+    let(:expected_ems_ref) { "#{@ems.subscription}/#{resource_group}/microsoft.authorization/locks/test-lock" }
 
     it_behaves_like "parses_event", "locks_delete_EndRequest"
     it_behaves_like "parses_event", "locks_write_EndRequest"


### PR DESCRIPTION
When we first started adding Azure provider support, we made the decision to incorporate backslashes. This proved to be unwise, as the Azure REST API uses forward slashes everywhere. The net result has been the proliferation of the `resource_uid` method and confusion in general. Plus, we've ended up with ems_ref's that are a mix of forward slashes and backslashes. It's just dumb.

This PR attempts to eliminate that issue by using forward slashes eveywhere.

Note that there is one test failure caused by a factory in the core repo that will need to be updated. In addition, a separate data migration will need to be implemented in parallel with this PR.