### PR TITLE
General rubocop cleanup

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -87,38 +87,38 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   def vm_start(vm, _options = {})
     vm.start
   rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
+    _log.error("vm=[#{vm.name}], error: #{err}")
   end
 
   def vm_stop(vm, _options = {})
     vm.stop
   rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
+    _log.error("vm=[#{vm.name}], error: #{err}")
   end
 
   def vm_suspend(vm, _options = {})
     vm.suspend
   rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
+    _log.error("vm=[#{vm.name}], error: #{err}")
   end
 
   def vm_destroy(vm, _options = {})
     vm.vm_destroy
   rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
+    _log.error("vm=[#{vm.name}], error: #{err}")
   end
 
   def vm_restart(vm, _options = {})
-    # TODO switch to vm.restart
+    # TODO: switch to vm.restart
     vm.raw_restart
   rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
+    _log.error("vm=[#{vm.name}], error: #{err}")
   end
 
   def vm_reboot_guest(vm, _options = {})
     vm.reboot_guest
   rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
+    _log.error("vm=[#{vm.name}], error: #{err}")
   end
 
   def vm_create_evm_snapshot(vm, options = {})

--- a/app/models/manageiq/providers/azure/cloud_manager/deployment.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/deployment.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Azure::CloudManager::Deployment
   extend ActiveSupport::Concern
 
   def deployment_failed?(deployment)
-    deployment.properties.provisioning_state.casecmp('failed') == 0
+    deployment.properties.provisioning_state.casecmp('failed').zero?
   end
 
   # Azure deployment does not contain failure reason. The actual reasons exist in the operations.
@@ -11,7 +11,7 @@ module ManageIQ::Providers::Azure::CloudManager::Deployment
   def deployment_failure_reason(deployment_operations)
     deployment_operations.each do |operation|
       message = operation_status_message(operation)
-      return message unless message.blank?
+      return message if message.present?
     end
     nil
   end

--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -13,7 +13,7 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
     event_monitor_handle.each_batch do |events|
       event_monitor_running
       _log.debug("#{log_prefix} Received events #{events.collect { |e| parse_event_type(e) }}")
-      @queue.enq events
+      @queue.enq(events)
       sleep_poll_normal
     end
   ensure
@@ -22,9 +22,9 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
 
   def process_event(event)
     if filtered?(event)
-      _log.debug "#{log_prefix} Skipping filtered Azure event #{parse_event_type(event)} for #{event["resourceId"]}"
+      _log.debug("#{log_prefix} Skipping filtered Azure event #{parse_event_type(event)} for #{event["resourceId"]}")
     else
-      _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{event["resourceId"]}"
+      _log.info("#{log_prefix} Caught event #{parse_event_type(event)} for #{event["resourceId"]}")
       event_hash = ManageIQ::Providers::Azure::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])
       EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
     end

--- a/app/models/manageiq/providers/azure/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_parser.rb
@@ -11,7 +11,7 @@ module ManageIQ::Providers::Azure::CloudManager::EventParser
     event_hash = {
       :source     => "AZURE",
       :timestamp  => event["eventTimestamp"],
-      :message    => event["description"].blank? ? nil : event["description"],
+      :message    => event["description"].presence,
       :ems_id     => ems_id,
       :event_type => event_type,
       :full_data  => event

--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -44,7 +44,7 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
   COUNTER_NAMES = COUNTER_INFO.flat_map { |i| i[:native_counters] }.uniq.to_set.freeze
 
   VIM_STYLE_COUNTERS = {
-    "cpu_usage_rate_average"      => {
+    "cpu_usage_rate_average"     => {
       :counter_key           => "cpu_usage_rate_average",
       :instance              => "",
       :capture_interval      => "20",
@@ -53,7 +53,7 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
       :unit_key              => "percent",
       :capture_interval_name => "realtime"
     },
-    "mem_usage_absolute_average"  => {
+    "mem_usage_absolute_average" => {
       :counter_key           => "mem_usage_absolute_average",
       :instance              => "",
       :capture_interval      => "20",
@@ -62,7 +62,7 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
       :unit_key              => "percent",
       :capture_interval_name => "realtime"
     },
-    "net_usage_rate_average"      => {
+    "net_usage_rate_average"     => {
       :counter_key           => "net_usage_rate_average",
       :instance              => "",
       :capture_interval      => "20",
@@ -71,7 +71,7 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
       :unit_key              => "kilobytespersecond",
       :capture_interval_name => "realtime"
     },
-    "disk_usage_rate_average"     => {
+    "disk_usage_rate_average"    => {
       :counter_key           => "disk_usage_rate_average",
       :instance              => "",
       :capture_interval      => "20",
@@ -120,7 +120,7 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
   end
 
   def perf_capture_data_azure(metrics_conn, storage_conn, start_time, end_time)
-    start_time -= 1.minutes # Get one extra minute so we can build the 20-second intermediate values
+    start_time -= 1.minute # Get one extra minute so we can build the 20-second intermediate values
 
     counters                = get_counters(metrics_conn)
     metrics_by_counter_name = metrics_by_counter_name(storage_conn, counters, start_time, end_time)

--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
@@ -66,7 +66,7 @@ class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ManageIQ::P
             _("%{name} does not exist on %{management}") % {:name => name, :management => ext_management_system.name}
     end
 
-    _log.error "stack=[#{name}], error: #{err}"
+    _log.error("stack=[#{name}], error: #{err}")
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
 

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -62,27 +62,27 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
     end
 
     cloud_options =
-    {
-      :name       => dest_name,
-      :location   => source.location,
-      :properties => {
-        :hardwareProfile => {
-          :vmSize => instance_type.name
-        },
-        :osProfile       => {
-          :adminUserName => options[:root_username],
-          :adminPassword => root_password,
-          :computerName  => dest_hostname
-        },
-        :storageProfile  => {
-          :osDisk        => {
-            :createOption => 'FromImage',
-            :caching      => 'ReadWrite',
-            :osType       => os
+      {
+        :name       => dest_name,
+        :location   => source.location,
+        :properties => {
+          :hardwareProfile => {
+            :vmSize => instance_type.name
+          },
+          :osProfile       => {
+            :adminUserName => options[:root_username],
+            :adminPassword => root_password,
+            :computerName  => dest_hostname
+          },
+          :storageProfile  => {
+            :osDisk => {
+              :createOption => 'FromImage',
+              :caching      => 'ReadWrite',
+              :osType       => os
+            }
           }
         }
       }
-    }
 
     # The -1 value is set in ProvisionWorkflow to distinguish between the
     # desire for a new Public IP address vs a private IP.
@@ -113,8 +113,7 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
 
   def log_clone_options(clone_options)
     dump_obj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
-    dump_obj(options, "#{_log.prefix} Prov Options:  ", $log, :info, :protected =>
-    {:path => workflow_class.encrypted_options_field_regs})
+    dump_obj(options, "#{_log.prefix} Prov Options:  ", $log, :info, :protected => {:path => workflow_class.encrypted_options_field_regs})
   end
 
   def region

--- a/app/models/manageiq/providers/azure/cloud_manager/refresher.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresher.rb
@@ -15,11 +15,11 @@ module ManageIQ::Providers::Azure
       # hash in the order we want them to appear.
       sorted_ems_targets = {}
       # pull out the IDs of cloud managers and reinsert them in a new hash first, to take advantage of preserved insertion order
-      cloud_manager_ids = @targets_by_ems_id.keys.select { |key| @ems_by_ems_id[key].kind_of? ManageIQ::Providers::Azure::CloudManager }
+      cloud_manager_ids = @targets_by_ems_id.keys.select { |key| @ems_by_ems_id[key].kind_of?(ManageIQ::Providers::Azure::CloudManager) }
       cloud_manager_ids.each { |ems_id| sorted_ems_targets[ems_id] = @targets_by_ems_id.delete(ems_id) }
       # now that the cloud managers have been removed from @targets_by_ems_id, move the rest of the values
       # over to the new hash and then replace @targets_by_ems_id.
-      @targets_by_ems_id.keys.each { |ems_id| sorted_ems_targets[ems_id] = @targets_by_ems_id.delete(ems_id) }
+      @targets_by_ems_id.each_key { |ems_id| sorted_ems_targets[ems_id] = @targets_by_ems_id.delete(ems_id) }
       @targets_by_ems_id = sorted_ems_targets
 
       super

--- a/app/models/manageiq/providers/azure/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/template.rb
@@ -10,7 +10,7 @@ class ManageIQ::Providers::Azure::CloudManager::Template < ::ManageIQ::Providers
   end
 
   def provider_object(connection = nil)
-    connection ||= self.ext_management_system.connect
-    connection.images[self.ems_ref]
+    connection ||= ext_management_system.connect
+    connection.images[ems_ref]
   end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
@@ -55,7 +55,7 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
                  end
   end
 
-  delegate :managed_disk?, to: :vm_object
+  delegate :managed_disk?, :to => :vm_object
 
   def managed_image?
     return false unless ems_ref =~ /^\/subscriptions\//i

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
@@ -30,7 +30,7 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
     end
 
     ost.scanTime = Time.now.utc unless ost.scanTime
-    armrest      = ext_management_system.connect 
+    armrest      = ext_management_system.connect
 
     begin
       miq_vm = MiqAzureVm.new(armrest, vm_args)

--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -60,19 +60,18 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManagerRefresh::Invento
   end
 
   def storage_accounts
-    # We want to always limit storage accounts, to avoid loading all account keys in full refresh. Right now we wat to
+    # We want to always limit storage accounts, to avoid loading all account keys in full refresh. Right now we want to
     # load just used storage accounts.
     return if instances.blank?
 
     used_storage_accounts = instances.map do |instance|
       disks = instance.properties.storage_profile.data_disks + [instance.properties.storage_profile.os_disk]
       disks.map do |disk|
-        unless instance.managed_disk?
-          disk_location = disk.try(:vhd).try(:uri)
-          if disk_location
-            uri = Addressable::URI.parse(disk_location)
-            uri.host.split('.').first
-          end
+        next if instance.managed_disk?
+        disk_location = disk.try(:vhd).try(:uri)
+        if disk_location
+          uri = Addressable::URI.parse(disk_location)
+          uri.host.split('.').first
         end
       end
     end.flatten.compact.to_set

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -42,7 +42,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
   end
 
   def network_routers
-    [] # TODO add targeted refresh
+    [] # TODO: add targeted refresh
   end
 
   def flavors
@@ -122,9 +122,9 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
                            set = Set.new(refs)
                            collect_inventory(:instances) { gather_data_for_this_region(@vmm) }.select do |instance|
                              uid = File.join(subscription_id,
-                                                instance.resource_group.downcase,
-                                                instance.type.downcase,
-                                                instance.name)
+                                             instance.resource_group.downcase,
+                                             instance.type.downcase,
+                                             instance.name)
 
                              set.include?(uid)
                            end

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -61,9 +61,9 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
   def instances
     collector.instances.each do |instance|
       uid = File.join(collector.subscription_id,
-                         instance.resource_group.downcase,
-                         instance.type.downcase,
-                         instance.name)
+                      instance.resource_group.downcase,
+                      instance.type.downcase,
+                      instance.name)
 
       # TODO(lsmola) we have a non lazy dependency, can we remove that?
       series = persister.flavors.find(instance.properties.hardware_profile.vm_size.downcase)

--- a/app/models/manageiq/providers/azure/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/network_manager.rb
@@ -351,9 +351,6 @@ class ManageIQ::Providers::Azure::Inventory::Parser::NetworkManager < ManageIQ::
     # the id string like this is suboptimal
     return nil unless id
     _, _, guid, _, resource_group, _, type, sub_type, name = id.split("/")
-    File.join(guid,
-                 resource_group.downcase,
-                 "#{type.downcase}/#{sub_type.downcase}",
-                 name)
+    File.join(guid, resource_group.downcase, type.downcase, sub_type.downcase, name)
   end
 end

--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -15,7 +15,6 @@ module ManageIQ::Providers::Azure::ManagerMixin
 
   module ClassMethods
     def raw_connect(client_id, client_key, azure_tenant_id, subscription, proxy_uri = nil, provider_region = nil)
-
       require 'azure-armrest'
 
       if subscription.blank?
@@ -87,7 +86,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
 
       azure_res.list_locations.each do |region|
         next if known_ems_regions.include?(region.name)
-        next if vms_in_region(azure_res, region.name).count == 0 # instances
+        next if vms_in_region(azure_res, region.name).count.zero? # instances
         # TODO: Check if images are == 0 and if so then skip
         new_emses << create_discovered_region(region.name, clientid, clientkey, azure_tenant_id, subscription, all_ems_names)
       end
@@ -97,7 +96,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
         new_emses << create_discovered_region("eastus", clientid, clientkey, azure_tenant_id, subscription, all_ems_names)
       end
 
-      EmsRefresh.queue_refresh(new_emses) unless new_emses.blank?
+      EmsRefresh.queue_refresh(new_emses) if new_emses.present?
 
       new_emses
     end

--- a/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
@@ -57,14 +57,11 @@ class ManageIQ::Providers::Azure::NetworkManager::RefreshParser
   end
 
   def resource_id_for_instance_id(id)
-    # TODO(lsmola) we really need to get rid of the building our own emf_ref, it makes crosslinking impossible, parsing
+    # TODO: (lsmola) we really need to get rid of the building our own emf_ref, it makes crosslinking impossible, parsing
     # the id string like this is suboptimal
     return nil unless id
     _, _, guid, _, resource_group, _, type, sub_type, name = id.split("/")
-    File.join(guid,
-                 resource_group.downcase,
-                 "#{type.downcase}/#{sub_type.downcase}",
-                 name)
+    File.join(guid, resource_group.downcase, type.downcase, sub_type.downcase, name)
   end
 
   def floating_ips
@@ -313,7 +310,7 @@ class ManageIQ::Providers::Azure::NetworkManager::RefreshParser
     if rule.properties.respond_to?(:destination_port_range)
       rule.properties.destination_port_range.split('-').first.to_i
     elsif rule.properties.respond_to?(:destination_port_ranges)
-      rule.properties.destination_port_ranges.flat_map{ |e| e.split('-') }.map(&:to_i).min
+      rule.properties.destination_port_ranges.flat_map { |e| e.split('-') }.map(&:to_i).min
     else
       nil # Old api-version
     end
@@ -323,7 +320,7 @@ class ManageIQ::Providers::Azure::NetworkManager::RefreshParser
     if rule.properties.respond_to?(:destination_port_range)
       rule.properties.destination_port_range.split('-').last.to_i
     elsif rule.properties.respond_to?(:destination_port_ranges)
-      rule.properties.destination_port_ranges.flat_map{ |e| e.split('-') }.map(&:to_i).max
+      rule.properties.destination_port_ranges.flat_map { |e| e.split('-') }.map(&:to_i).max
     else
       nil # Old api-version
     end


### PR DESCRIPTION
This fixes 65 of the current 135 rubocop violations under `app/models`. Some were not fixed because they were more invasive, possibly invalid, require further discussion, or simply annoy me.