### PR TITLE
Exclude refresher files from AccessorMethodName warnings

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -3,3 +3,7 @@ GlobalVars:
   # Loggers
   - $log
   - $azure_log
+Naming/AccessorMethodName:
+  Exclude:
+    - app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+    - app/models/manageiq/providers/azure/network_manager/refresh_parser.rb


### PR DESCRIPTION
This warning is generally meant to dissuade people from using Java style accessors. However, these aren't really accessor methods in the traditional sense, they're collection methods, so I think they should be excluded from the usual rubocop checks. Plus, all the other providers do the same thing.