### PR TITLE
Update azure-armrest gem to 0.9.11

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.9.10"
+  s.add_dependency "azure-armrest", "~>0.9.11"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The 0.9.11 release of the Azure armrest gem adds the `ResourceProviderService#supported?` method, as well as automatic environment profile discovery.

This is needed for https://bugzilla.redhat.com/show_bug.cgi?id=1566600, and will come in handy for custom endpoints, which will be part of https://bugzilla.redhat.com/show_bug.cgi?id=1339398.


