### PR TITLE
Archive VM with no status

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -70,12 +70,15 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
 
       rg_ems_ref = collector.get_resource_group_ems_ref(instance)
 
+      # We want to archive VMs with no status
+      next if (status = collector.power_status(instance)).blank?
+
       persister_instance = persister.vms.build(
         :uid_ems             => uid,
         :ems_ref             => uid,
         :name                => instance.name,
         :vendor              => "azure",
-        :raw_power_state     => collector.power_status(instance),
+        :raw_power_state     => status,
         :flavor              => series,
         :location            => instance.location,
         # TODO(lsmola) for release > g, we can use secondary indexes for this as


### PR DESCRIPTION
Archive VM with no status, which should solve that VMs are not
sometimes archived by targeted refresh. We receive event that VM
was deleted, but when doing API query, the Vm is still returned.
When fetching Vm's state, we do get uknown state (azure returns 404)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1575773