### PR TITLE
Added French and Australian regions, fix Southeast Asia description.

### DIFF
--- a/app/models/manageiq/providers/azure/regions.rb
+++ b/app/models/manageiq/providers/azure/regions.rb
@@ -9,6 +9,14 @@ module ManageIQ
           :name        => "australiaeast",
           :description => _("Australia East"),
         },
+        "australiacentral"   => {
+          :name        => "australiacentral",
+          :description => _("Australia Central"),
+        },
+        "australiacentral2"  => {
+          :name        => "australiacentral2",
+          :description => _("Australia Central 2"),
+        },
         "australiasoutheast" => {
           :name        => "australiasoutheast",
           :description => _("Australia Southeast"),
@@ -44,6 +52,14 @@ module ManageIQ
         "eastus2"            => {
           :name        => "eastus2",
           :description => _("East US 2"),
+        },
+        "francecentral"      => {
+          :name        => "francecentral",
+          :description => _("France Central"),
+        },
+        "francesouth"        => {
+          :name        => "francesouth",
+          :description => _("France South"),
         },
         "germanycentral"     => {
           :name        => "germanycentral",
@@ -83,7 +99,7 @@ module ManageIQ
         },
         "southeastasia"      => {
           :name        => "southeastasia",
-          :description => _("South East Asia"),
+          :description => _("Southeast Asia"),
         },
         "southindia"         => {
           :name        => "southindia",

--- a/spec/models/manageiq/providers/azure/regions_spec.rb
+++ b/spec/models/manageiq/providers/azure/regions_spec.rb
@@ -7,9 +7,9 @@ describe ManageIQ::Providers::Azure::Regions do
     # You can get these by running Azure::Armrest::ArmrestService#list_locations
     def azure_regions
       %w(
-        australiaeast australiasoutheast brazilsouth canadacentral canadaeast
-        centralindia centralus eastasia eastus eastus2
-        germanycentral germanynortheast japaneast japanwest koreacentral
+        australiacentral australiacentral2 australiaeast australiasoutheast brazilsouth
+        canadacentral canadaeast centralindia centralus eastasia eastus eastus2
+        francecentral francesouth germanycentral germanynortheast japaneast japanwest koreacentral
         koreasouth northcentralus northeurope southcentralus southeastasia
         southindia uksouth ukwest usgovarizona usgoviowa usgovtexas usgovvirginia
         westcentralus westeurope westindia westus westus2


### PR DESCRIPTION
This adds the new regions to the regions.rb file:

* australiacentral
* australiacentral2
* francecentral
* francesouth

It also fixes the description for southeastasia to "Southeast Asia" to match the CLI output.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1581652