### PR TITLE
Add Germany North and Germany West Central regions

### DIFF
--- a/app/models/manageiq/providers/azure/regions.rb
+++ b/app/models/manageiq/providers/azure/regions.rb
@@ -65,9 +65,17 @@ module ManageIQ
           :name        => "germanycentral",
           :description => _("Germany Central"),
         },
+        "germanynorth"       => {
+          :name        => "germanynorth",
+          :description => _("Germany North"),
+        },
         "germanynortheast"   => {
           :name        => "germanynortheast",
           :description => _("Germany Northeast"),
+        },
+        "germanywestcentral" => {
+          :name        => "germanywestcentral",
+          :description => _("Germany West Central"),
         },
         "japaneast"          => {
           :name        => "japaneast",

--- a/spec/models/manageiq/providers/azure/regions_spec.rb
+++ b/spec/models/manageiq/providers/azure/regions_spec.rb
@@ -7,10 +7,12 @@ describe ManageIQ::Providers::Azure::Regions do
     # You can get these by running Azure::Armrest::ArmrestService#list_locations
     def azure_regions
       %w(
-        australiacentral australiacentral2 australiaeast australiasoutheast brazilsouth
-        canadacentral canadaeast centralindia centralus eastasia eastus eastus2
-        francecentral francesouth germanycentral germanynortheast japaneast japanwest koreacentral
-        koreasouth northcentralus northeurope southcentralus southeastasia
+        australiacentral australiacentral2 australiaeast australiasoutheast
+        brazilsouth canadacentral canadaeast centralindia centralus eastasia
+        eastus eastus2 francecentral francesouth
+        germanycentral germanynorth germanynortheast germanywestcentral
+        japaneast japanwest koreacentral koreasouth
+        northcentralus northeurope southcentralus southeastasia
         southindia uksouth ukwest usgovarizona usgoviowa usgovtexas usgovvirginia
         westcentralus westeurope westindia westus westus2
       )


### PR DESCRIPTION
Adds Germany North and Germany West Central.

Note that these are announced regions, but you won't see them in the Azure REST API results for locations because they're managed by T-Systems in Germany to comply with German regulations. See https://azure.microsoft.com/en-us/global-infrastructure/germany/ for more information.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1572376