### PR TITLE
Add sysprep template support

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
@@ -36,6 +36,10 @@ class ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow < ManageIQ::Pr
     end
   end
 
+  def supports_sysprep?
+    true
+  end
+
   def self.provider_model
     ManageIQ::Providers::Azure::CloudManager
   end

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -205,6 +205,12 @@ describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
     end
   end
 
+  context "#supports_sysprep?" do
+    it "returns the expected boolean value" do
+      expect(workflow.supports_sysprep?).to eql(true)
+    end
+  end
+
   describe "#make_request" do
     let(:alt_user) { FactoryGirl.create(:user_with_group) }
     it "creates and update a request" do


### PR DESCRIPTION
Support for sysprep was added in https://github.com/ManageIQ/manageiq/pull/17293. However, after some discussion it was decided to set the default to false.

This PR simply redefines the `supports_sysprep?` method to return true. With that in place, sysprep templates for Windows images are then visible in the provisioning screen.

![sysprep_template_provision_screenshot](https://user-images.githubusercontent.com/78529/40926352-3dbee67e-67d9-11e8-88f9-af80cd1b9bd0.jpg)
