### PR TITLE
Fix root disk size, swap disk size

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -239,8 +239,8 @@ module ManageIQ::Providers
           :cpus           => s.number_of_cores, # where are the virtual CPUs??
           :cpu_cores      => s.number_of_cores,
           :memory         => s.memory_in_mb.megabytes,
-          :root_disk_size => s.os_disk_size_in_mb * 1024,
-          :swap_disk_size => s.resource_disk_size_in_mb * 1024
+          :root_disk_size => s.os_disk_size_in_mb.megabytes,
+          :swap_disk_size => s.resource_disk_size_in_mb.megabytes
         }
         return uid, new_result
       end

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -42,8 +42,8 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
         :cpus           => flavor.number_of_cores, # where are the virtual CPUs??
         :cpu_cores      => flavor.number_of_cores,
         :memory         => flavor.memory_in_mb.megabytes,
-        :root_disk_size => flavor.os_disk_size_in_mb * 1024,
-        :swap_disk_size => flavor.resource_disk_size_in_mb * 1024,
+        :root_disk_size => flavor.os_disk_size_in_mb.megabytes,
+        :swap_disk_size => flavor.resource_disk_size_in_mb.megabytes,
         :enabled        => true
       )
     end

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -367,8 +367,8 @@ module AzureRefresherSpecCommon
       :supports_hvm             => nil,
       :supports_paravirtual     => nil,
       :block_storage_based_only => nil,
-      :root_disk_size           => 1023.megabytes,
-      :swap_disk_size           => 20.megabytes
+      :root_disk_size           => 1_047_552.megabytes,
+      :swap_disk_size           => 20_480.megabytes
     )
 
     expect(@flavor.ext_management_system).to eq(@ems)
@@ -472,7 +472,7 @@ module AzureRefresherSpecCommon
       :annotation          => nil,
       :cpu_sockets         => 1,
       :memory_mb           => 768,
-      :disk_capacity       => 1043.megabyte,
+      :disk_capacity       => 1_047_552.megabyte + 20_480.megabyte,
       :bitness             => nil,
       :virtualization_type => nil
     )
@@ -623,7 +623,7 @@ module AzureRefresherSpecCommon
       :annotation         => nil,
       :cpu_sockets        => 1,
       :memory_mb          => 768,
-      :disk_capacity      => 1043.megabytes,
+      :disk_capacity      => 1_047_552.megabytes + 20_480.megabytes,
       :bitness            => nil
     )
 


### PR DESCRIPTION
We are mistakenly storing kilobytes instead of bytes for `root_disk_size` and `swap_disk_size` at the moment, which also affects the hardware information. Ultimately, this is causing automation issues where disk quotas have been set.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1564495