### PR TITLE
Set parent for VM's where possible

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -633,6 +633,7 @@ module ManageIQ::Providers
             :raw_power_state    => 'never',
             :template           => true,
             :publicly_available => true,
+            :version            => image.version,
             :hardware           => {
               :bitness  => 64,
               :guest_os => 'unknown'
@@ -690,16 +691,6 @@ module ManageIQ::Providers
             :section => 'labels',
           }
         end
-      end
-
-      def determine_instance_parent(instance)
-        if instance.managed_disk?
-          parent_ref = instance.properties.storage_profile.try(:image_reference).try(:id)
-        else
-          parent_ref = instance.properties.storage_profile.try(:os_disk).try(:image).try(:uri)
-        end
-
-        parent_ref ? @data_index.fetch_path(:vms, parent_ref) : nil
       end
 
       delegate :map_labels, :to => :@tag_mapper

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -287,7 +287,7 @@ module ManageIQ::Providers
           :orchestration_stack => @data_index.fetch_path(:orchestration_stacks, @resource_to_stack[uid]),
           :availability_zone   => @data_index.fetch_path(:availability_zones, 'default'),
           :resource_group      => @data_index.fetch_path(:resource_groups, rg_ems_ref),
-          :parent_vm           => determine_instance_parent(instance),
+          :parent_vm           => @data_index.fetch_path(:vms, parent_ems_ref(instance)),
           :labels              => labels,
           :tags                => map_labels('VmAzure', labels),
           :hardware            => {

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -71,6 +71,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
       series = persister.flavors.find(instance.properties.hardware_profile.vm_size.downcase)
 
       rg_ems_ref = collector.get_resource_group_ems_ref(instance)
+      parent_ref = collector.parent_ems_ref(instance)
 
       # We want to archive VMs with no status
       next if (status = collector.power_status(instance)).blank?
@@ -83,6 +84,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
         :raw_power_state     => status,
         :flavor              => series,
         :location            => instance.location,
+        :parent              => persister.vms.lazy_find(parent_ref),
         # TODO(lsmola) for release > g, we can use secondary indexes for this as
         :orchestration_stack => persister.stack_resources_secondary_index[instance.id.downcase],
         :availability_zone   => persister.availability_zones.lazy_find('default'),

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -84,7 +84,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
         :raw_power_state     => status,
         :flavor              => series,
         :location            => instance.location,
-        :parent              => persister.miq_templates.lazy_find(parent_ref),
+        :genealogy_parent    => persister.miq_templates.lazy_find(parent_ref),
         # TODO(lsmola) for release > g, we can use secondary indexes for this as
         :orchestration_stack => persister.stack_resources_secondary_index[instance.id.downcase],
         :availability_zone   => persister.availability_zones.lazy_find('default'),

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -84,7 +84,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
         :raw_power_state     => status,
         :flavor              => series,
         :location            => instance.location,
-        :parent              => persister.vms.lazy_find(parent_ref),
+        :parent              => persister.miq_templates.lazy_find(parent_ref),
         # TODO(lsmola) for release > g, we can use secondary indexes for this as
         :orchestration_stack => persister.stack_resources_secondary_index[instance.id.downcase],
         :availability_zone   => persister.availability_zones.lazy_find('default'),

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -44,14 +44,12 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
   # Return the parent image for the given instance, if possible. Note that we
   # cannot currently find the parent if it is a marketplace image.
   #
-  def determine_instance_parent(instance)
+  def parent_ems_ref(instance)
     if instance.managed_disk?
-      parent_ref = instance.properties.storage_profile.try(:image_reference).try(:id)
+      instance.properties.storage_profile.try(:image_reference).try(:id)
     else
-      parent_ref = instance.properties.storage_profile.try(:os_disk).try(:image).try(:uri)
+      instance.properties.storage_profile.try(:os_disk).try(:image).try(:uri)
     end
-
-    parent_ref ? @data_index.fetch_path(:vms, parent_ref) : nil
   end
 
   def process_collection(collection, key, store_in_data = true)

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -41,6 +41,16 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     Pathname.new(path).cleanpath.to_s
   end
 
+  def determine_instance_parent(instance)
+    if instance.managed_disk?
+      parent_ref = instance.properties.storage_profile.try(:image_reference).try(:id)
+    else
+      parent_ref = instance.properties.storage_profile.try(:os_disk).try(:image).try(:uri)
+    end
+
+    parent_ref ? @data_index.fetch_path(:vms, parent_ref) : nil
+  end
+
   def process_collection(collection, key, store_in_data = true)
     @data[key] ||= [] if store_in_data
 

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -41,6 +41,9 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     Pathname.new(path).cleanpath.to_s
   end
 
+  # Return the parent image for the given instance, if possible. Note that we
+  # cannot currently find the parent if it is a marketplace image.
+  #
   def determine_instance_parent(instance)
     if instance.managed_disk?
       parent_ref = instance.properties.storage_profile.try(:image_reference).try(:id)

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -152,7 +152,7 @@ module AzureRefresherSpecCommon
       :hardware                          => 14,
       :network                           => 23,
       :operating_system                  => 13,
-      :relationship                      => 0,
+      :relationship                      => 2,
       :orchestration_template            => 26,
       :orchestration_stack               => 29,
       :orchestration_stack_parameter     => 261,
@@ -638,7 +638,7 @@ module AzureRefresherSpecCommon
                                "Microsoft.Compute/Images/miq-test-container/"\
                                "test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd"
 
-    vm_resource_id = "2586c64b-38b4-4527-a140-012d49dfc02c/miq-azure-test4/"\
+    vm_resource_id = "#{@ems.subscription}/miq-azure-test4/"\
                         "microsoft.compute/virtualmachines/dbergerprov1"
 
     vm = ManageIQ::Providers::Azure::CloudManager::Vm.find_by(:ems_ref => vm_resource_id)

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -633,6 +633,20 @@ module AzureRefresherSpecCommon
     expect(v.hardware.networks.size).to eql(2)
   end
 
+  def assert_specific_parent
+    template_resource_id = "https://miqazuretest14047.blob.core.windows.net/system/"\
+                               "Microsoft.Compute/Images/miq-test-container/"\
+                               "test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd"
+
+    vm_resource_id = "2586c64b-38b4-4527-a140-012d49dfc02c/miq-azure-test4/"\
+                        "microsoft.compute/virtualmachines/dbergerprov1"
+
+    vm = ManageIQ::Providers::Azure::CloudManager::Vm.find_by(:ems_ref => vm_resource_id)
+    template = ManageIQ::Providers::Azure::CloudManager::Template.find_by(:ems_ref => template_resource_id)
+
+    expect(vm.parent).to eql(template)
+  end
+
   def assert_specific_template
     template_resource_id = "https://miqazuretest14047.blob.core.windows.net/system/"\
                                "Microsoft.Compute/Images/miq-test-container/"\

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -118,6 +118,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
           assert_specific_managed_disk
           assert_specific_resource_group
           assert_specific_router
+          assert_specific_parent
         end
       end
     end


### PR DESCRIPTION
This PR sets the parent image for virtual machines in Azure. Previously, this was only getting set via provisioning within the tool.

Note that this does not currently support marketplace images. Setting this is not impossible, but will require a change in how we collect and/or store marketplace image data. This is because Azure always sets the version to "latest" for a VM, whereas there can be many different versions for the same markeplace image, and more are added over time.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1478889

~~WIP for now until targeted refresh is fixed and the specs pass.~~