### PR TITLE
Update series name to work with Azure stack

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -230,18 +230,20 @@ module ManageIQ::Providers
         return uid, new_result
       end
 
-      def parse_series(s)
-        name = uid = s.name.downcase
+      def parse_series(series)
+        uid = series.name.downcase
+
         new_result = {
-          :type           => "ManageIQ::Providers::Azure::CloudManager::Flavor",
+          :type           => ManageIQ::Providers::Azure::CloudManager::Flavor.name,
           :ems_ref        => uid,
-          :name           => name,
-          :cpus           => s.number_of_cores, # where are the virtual CPUs??
-          :cpu_cores      => s.number_of_cores,
-          :memory         => s.memory_in_mb.megabytes,
-          :root_disk_size => s.os_disk_size_in_mb.megabytes,
-          :swap_disk_size => s.resource_disk_size_in_mb.megabytes
+          :name           => series.name,
+          :cpus           => series.number_of_cores,
+          :cpu_cores      => series.number_of_cores,
+          :memory         => series.memory_in_mb.megabytes,
+          :root_disk_size => series.os_disk_size_in_mb.megabytes,
+          :swap_disk_size => series.resource_disk_size_in_mb.megabytes
         }
+
         return uid, new_result
       end
 

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -46,13 +46,13 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
   end
 
   def flavors
-    refs = name_references(:flavors)
+    refs = references(:flavors)
 
     return [] if refs.blank?
     set = Set.new(refs)
 
     collect_inventory_targeted(:series) { @vmm.series(@ems.provider_region) }.select do |flavor|
-      set.include?(flavor.name.downcase)
+      set.include?(flavor.name.downcase) # ems_ref is downcased flavor name
     end
   rescue ::Azure::Armrest::Exception => err
     _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
@@ -521,7 +521,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
   def infer_related_vm_ems_refs_api!
     instances.each do |instance|
       # TODO(lsmola) add API scanning
-      target.add_target(:association => :flavors, :manager_ref => {:name => instance.properties.hardware_profile.vm_size.downcase})
+      target.add_target(:association => :flavors, :manager_ref => {:ems_ref => instance.properties.hardware_profile.vm_size.downcase})
       add_simple_target!(:availability_zones, 'default')
       add_simple_target!(:resource_groups, get_resource_group_ems_ref(instance))
       instance.properties.network_profile.network_interfaces.collect(&:id).each do |network_port_ems_ref|

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -35,9 +35,10 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
 
   def flavors
     collector.flavors.each do |flavor|
-      name = uid = flavor.name.downcase
+      name = flavor.name
+
       persister.flavors.build(
-        :ems_ref        => uid,
+        :ems_ref        => name.downcase,
         :name           => name,
         :cpus           => flavor.number_of_cores, # where are the virtual CPUs??
         :cpu_cores      => flavor.number_of_cores,

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -350,13 +350,10 @@ module AzureRefresherSpecCommon
   end
 
   def assert_specific_flavor
-    @flavor_not_found = ManageIQ::Providers::Azure::CloudManager::Flavor.where(:name => "Basic_A0").first
-    expect(@flavor_not_found).to eq(nil)
-
-    @flavor = ManageIQ::Providers::Azure::CloudManager::Flavor.where(:name => "basic_a0").first
+    @flavor = ManageIQ::Providers::Azure::CloudManager::Flavor.where(:ems_ref => "basic_a0").first
 
     expect(@flavor).to have_attributes(
-      :name                     => "basic_a0",
+      :name                     => "Basic_A0",
       :description              => nil,
       :enabled                  => true,
       :cpus                     => 1,
@@ -1084,16 +1081,16 @@ module AzureRefresherSpecCommon
   end
 
   def flavor_target
-    flavor_resource_name = "basic_a0"
+    flavor_resource_id = "basic_a0"
     ManagerRefresh::Target.new(:manager     => @ems,
                                :association => :flavors,
-                               :manager_ref => {:name => flavor_resource_name})
+                               :manager_ref => {:ems_ref => flavor_resource_id})
   end
 
   def non_existent_flavor_target
-    flavor_resource_name = "non_existent"
+    flavor_resource_id = "non_existent"
     ManagerRefresh::Target.new(:manager     => @ems,
                                :association => :flavors,
-                               :manager_ref => {:name => flavor_resource_name})
+                               :manager_ref => {:ems_ref => flavor_resource_id})
   end
 end


### PR DESCRIPTION
Apparently flavor names are case sensitive for Azure Stack. This PR keeps the downcased name for the `ems_ref`, but retains the original name for the `name` field.

Addresses https://github.com/ManageIQ/manageiq-providers-azure/issues/252