### PR TITLE
Update azure-armrest gem to 0.9.12

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.9.11"
+  s.add_dependency "azure-armrest", "~>0.9.12"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This bumps the required azure-armrest gem to 0.9.12. That version includes a fix for the `list_api_versions` method, which we need for handling invalid `api-version` strings.

Part of https://bugzilla.redhat.com/show_bug.cgi?id=1566613