### PR TITLE
Default to StandardError if a connection cannot be made

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -50,7 +50,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
       raise # Raise before falling into catch-all block below
     rescue StandardError => err
       _log.error("Error Class=#{err.class.name}, Message=#{err.message}, Backtrace=#{err.backtrace}")
-      raise MiqException::MiqInvalidCredentialsError, _("Unexpected response returned from system: %{error_message}") % {:error_message => err.message}
+      raise err, _("Unexpected response returned from system: %{error_message}") % {:error_message => err.message}
     end
 
     def environment_for(region)

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -102,7 +102,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
       end
       it "handles unknown error" do
         allow(Azure::Armrest::Configuration).to receive(:new).and_raise(StandardError)
-        expect { @e.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError, /Unexpected response returned*/)
+        expect { @e.verify_credentials }.to raise_error(StandardError, /Unexpected response returned*/)
       end
 
       it "handles incorrect password" do


### PR DESCRIPTION
Currently the `connection_rescue_block` is defaulting to a `MiqCredentialsError` as a last resort when an unexpected connection error occurs. As per @jrafanie's advice, this should be changed to re-raise `StandardError` so that more graceful handling will occur via the `AuthenticationMixin` module from the core repo, since it is now a "valid" error.

It's also just more sensical since by the time we fall into this bucket, since it's probably not an actual credentials error.

While we obviously cannot solve problems on Azure's end (which is typically when this error will be reached), we can handle it more gracefully with this change.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600968