### PR TITLE
InventoryCollection builder_params -> default_values

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/azure/inventory/persister/definitions/network_collections.rb
@@ -30,7 +30,7 @@ module ManageIQ::Providers::Azure::Inventory::Persister::Definitions::NetworkCol
 
   # TODO: Builder params
   def add_cloud_subnets
-    add_collection(network, :cloud_subnets, :builder_params => nil) do |builder|
+    add_collection(network, :cloud_subnets, :default_values => nil) do |builder|
       builder.add_properties(:parent_inventory_collections => %i(cloud_networks))
 
       builder.add_targeted_arel(


### PR DESCRIPTION
**Issue**: https://github.com/ManageIQ/manageiq/issues/17396

- [x] **depends on** https://github.com/ManageIQ/manageiq/pull/17742

Removing "builder_params" term from all inventory_collection related classes
