### PR TITLE
Update azure-armrest gem to 0.9.13

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.9.12"
+  s.add_dependency "azure-armrest", "~>0.9.13"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This updates the azure-armrest gem to 0.9.13. Along with some other minor tweaks, the most notable change is an update the AD authority endpoint for USGov environments.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1627520