### PR TITLE
Fix parent association in graph refresh

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -72,7 +72,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
       series = persister.flavors.find(instance.properties.hardware_profile.vm_size.downcase)
 
       rg_ems_ref = collector.get_resource_group_ems_ref(instance)
-      parent_ref = collector.parent_ems_ref(instance).try(:downcase)
+      parent_ref = collector.parent_ems_ref(instance)
 
       # We want to archive VMs with no status
       next if (status = collector.power_status(instance)).blank?

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -72,7 +72,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
       series = persister.flavors.find(instance.properties.hardware_profile.vm_size.downcase)
 
       rg_ems_ref = collector.get_resource_group_ems_ref(instance)
-      parent_ref = collector.parent_ems_ref(instance)
+      parent_ref = collector.parent_ems_ref(instance).try(:downcase)
 
       # We want to archive VMs with no status
       next if (status = collector.power_status(instance)).blank?

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -46,7 +46,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
   #
   def parent_ems_ref(instance)
     if instance.managed_disk?
-      instance.properties.storage_profile.try(:image_reference).try(:id)
+      instance.properties.storage_profile.try(:image_reference).try(:id).try(:downcase)
     else
       instance.properties.storage_profile.try(:os_disk).try(:image).try(:uri)
     end


### PR DESCRIPTION
The when setting a parent, the `parent_ems_ref` helper method pulls its information straight from the JSON properties. Consequently, we need to explicitly downcase it to ensure that the association is set correctly.