### PR TITLE
[WIP] Only select the VM fields that Azure uses

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm.rb
@@ -15,6 +15,7 @@ class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudM
     cpu_shares_level
     deprecated
     fault_tolerance
+    format
     linked_clone
     memory_hot_add_enabled
     memory_hot_add_increment
@@ -24,6 +25,7 @@ class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudM
     memory_reserve_expand
     memory_shares
     memory_shares_level
+    registered
     tools_status
   ].freeze
 

--- a/app/models/manageiq/providers/azure/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm.rb
@@ -2,30 +2,34 @@ class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudM
   include_concern 'Operations'
   include_concern 'ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared'
 
-  # Only select the columns we actually use for the Azure provider.
+  UNSUPPORTED_COLUMNS = %w[
+    busy
+    config_xml
+    cpu_affinity
+    cpu_hot_add_enabled
+    cpu_hot_remove_enabled
+    cpu_limit
+    cpu_reserve
+    cpu_reserve_expand
+    cpu_shares
+    cpu_shares_level
+    deprecated
+    fault_tolerance
+    linked_clone
+    memory_hot_add_enabled
+    memory_hot_add_increment
+    memory_hot_add_limit
+    memory_limit
+    memory_reserve
+    memory_reserve_expand
+    memory_shares
+    memory_shares_level
+    tools_status
+  ].freeze
+
+  # Exclude columns that are not used by Azure.
   default_scope do
-    select([
-      :availability_zone_id,
-      :cloud,
-      :created_on,
-      :description,
-      :ems_id,
-      :ems_ref,
-      :flavor_id,
-      :guid,
-      :location,
-      :name,
-      :orchestration_stack_id,
-      :power_state,
-      :publicly_available,
-      :raw_power_state,
-      :resource_group_id,
-      :state_changed_on,
-      :tenant_id,
-      :type,
-      :uid_ems,
-      :vendor
-    ])
+    select(VmOrTemplate.column_names - UNSUPPORTED_COLUMNS)
   end
 
   #

--- a/app/models/manageiq/providers/azure/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm.rb
@@ -2,6 +2,32 @@ class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudM
   include_concern 'Operations'
   include_concern 'ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared'
 
+  # Only select the columns we actually use for the Azure provider.
+  default_scope do
+    select([
+      :availability_zone_id,
+      :cloud,
+      :created_on,
+      :description,
+      :ems_id,
+      :ems_ref,
+      :flavor_id,
+      :guid,
+      :location,
+      :name,
+      :orchestration_stack_id,
+      :power_state,
+      :publicly_available,
+      :raw_power_state,
+      :resource_group_id,
+      :state_changed_on,
+      :tenant_id,
+      :type,
+      :uid_ems,
+      :vendor
+    ])
+  end
+
   #
   # Relationship methods
   #


### PR DESCRIPTION
This is a minor performance enhancement that I worked on after realizing that a significant number of columns in the `vms` table aren't used by Azure. Many only apply to VMWare. So I added a `default_scope` on the `ManageIQ::Providers::Azure::CloudManager::Vm` model.

The net result is a 16 byte reduction per Vm object (128 vs 144), as reported by `ObjectSpace.memsize_of`, in my local testing. While individually small, this would add up with significant numbers of Vm's. It also makes inspection easier in the console, since it only shows the fields we care about.

This is a WIP for now, as it appears to blow up a custom `calculate` method that was added as a core extension:

https://github.com/ManageIQ/manageiq/blob/master/lib/extensions/ar_virtual.rb#L781