### PR TITLE
Handle possibility that disk might not have sku

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -399,7 +399,7 @@ module ManageIQ::Providers
             blob_name = uri.basename
 
             storage_acct = @storage_accounts.find { |s| s.name.casecmp(storage_name).zero? }
-            mode = storage_acct.sku.name
+            mode = storage_acct.try(:sku).try(:name)
 
             if @options.get_unmanaged_disk_space && disk_size.nil?
               storage_keys = @sas.list_account_keys(storage_acct.name, storage_acct.resource_group)

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -381,7 +381,7 @@ module ManageIQ::Providers
 
           if managed_disk
             disk_size = managed_disk.properties.disk_size_gb.gigabytes
-            mode      = managed_disk.sku.name
+            mode      = managed_disk.try(:sku).try(:name)
           else
             _log.warn("Unable to find disk information for #{instance.name}/#{instance.resource_group}")
             disk_size = nil

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -169,7 +169,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
 
       if managed_disk
         disk_size = managed_disk.properties.disk_size_gb.gigabytes
-        mode      = managed_disk.sku.name
+        mode      = managed_disk.try(:sku).try(:name)
       else
         _log.warn("Unable to find disk information for #{instance.name}/#{instance.resource_group}")
         disk_size = nil

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -563,7 +563,7 @@ module AzureRefresherSpecCommon
 
     expect(disk).to have_attributes(
       :location => uri,
-      :mode     => 'Standard_RAGRS',
+      #:mode     => 'Standard_RAGRS',
       :size     => 32_212_254_720 # 30gb, approx
     )
   end

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -563,6 +563,7 @@ module AzureRefresherSpecCommon
 
     expect(disk).to have_attributes(
       :location => uri,
+      :mode     => 'Standard_RAGRS',
       :size     => 32_212_254_720 # 30gb, approx
     )
   end
@@ -579,6 +580,7 @@ module AzureRefresherSpecCommon
                                    "#{@vm_group}/providers/Microsoft.Compute/disks/"\
                                    "#{@managed_os_disk}".downcase)
     expect(disk.size).to eql(30.gigabytes)
+    expect(disk.mode).to eql('Standard_LRS')
   end
 
   def assert_specific_resource_group


### PR DESCRIPTION
Apparently it's possible for a managed disk to not have a sku. This handles that possibility.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1642478