### PR TITLE
Handle regions where metrics are unsupported

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -209,6 +209,11 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
           .list('Microsoft.Compute', 'virtualMachines', target.name, target.resource_group.name)
           .select { |m| m.name.value.in?(COUNTER_NAMES) }
       end
+    rescue ::Azure::Armrest::BadRequestException # Probably means region is not supported
+      msg = "Problem collecting metrics for #{target.name}/#{target.resource_group.name}. "\
+            "Region [#{ems.provider_region}] may not be supported."
+      _log.warn(msg)
+      counters = []
     rescue ::Azure::Armrest::RequestTimeoutException # Problem on Azure side
       _log.warn("Timeout attempting to collect metrics definitions for: #{target.name}/#{target.resource_group.name}. Skipping.")
       counters = []

--- a/spec/models/manageiq/providers/azure/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/metrics_capture_spec.rb
@@ -9,11 +9,11 @@ describe ManageIQ::Providers::Azure::CloudManager::MetricsCapture do
     let(:metric) { described_class.new(self) }
     let(:armrest_service) { double('::Azure::Armrest::ArmrestService') }
 
-    before {
+    before do
       allow(self).to receive(:ext_management_system).and_return(ems)
       allow(self).to receive(:name).and_return('target1')
       allow(self).to receive(:resource_group).and_return(group)
-    }
+    end
 
     it "returns an empty array if the insights service is not registered" do
       allow(ems).to receive(:insights?).and_return(false)
@@ -22,21 +22,21 @@ describe ManageIQ::Providers::Azure::CloudManager::MetricsCapture do
 
     it "returns an empty array if the region is not supported" do
       allow(ems).to receive(:insights?).and_return(true)
-      allow(armrest_service).to receive(:list).and_raise(::Azure::Armrest::BadRequestException.new('x','y','z'))
+      allow(armrest_service).to receive(:list).and_raise(::Azure::Armrest::BadRequestException.new('x', 'y', 'z'))
       expect($log).to receive(:warn).with(/problem collecting metrics/i)
       expect(metric.send(:get_counters, armrest_service)).to eql([])
     end
 
     it "returns an empty array if a timeout occurs" do
       allow(ems).to receive(:insights?).and_return(true)
-      allow(armrest_service).to receive(:list).and_raise(::Azure::Armrest::RequestTimeoutException.new('x','y','z'))
+      allow(armrest_service).to receive(:list).and_raise(::Azure::Armrest::RequestTimeoutException.new('x', 'y', 'z'))
       expect($log).to receive(:warn).with(/timeout attempting to collect metrics/i)
       expect(metric.send(:get_counters, armrest_service)).to eql([])
     end
 
     it "returns an empty array if the VM could not be found" do
       allow(ems).to receive(:insights?).and_return(true)
-      allow(armrest_service).to receive(:list).and_raise(::Azure::Armrest::NotFoundException.new('x','y','z'))
+      allow(armrest_service).to receive(:list).and_raise(::Azure::Armrest::NotFoundException.new('x', 'y', 'z'))
       expect($log).to receive(:warn).with(/could not find metrics definitions/i)
       expect(metric.send(:get_counters, armrest_service)).to eql([])
     end
@@ -151,7 +151,8 @@ describe ManageIQ::Providers::Azure::CloudManager::MetricsCapture do
     storage_acc_service = double(
       "Azure::Armrest::StorageAccountService",
       :name           => "defaultstorage",
-      :resource_group => "Default-Storage")
+      :resource_group => "Default-Storage"
+    )
 
     allow_any_instance_of(described_class).to receive(:with_metrics_services)
       .and_yield(metrics_service, storage_acc_service)


### PR DESCRIPTION
It seems that even if a region has the Microsoft.Insights provider enabled, it still does not necessarily support collection of certain metrics in certain regions, e.g. Germany.

In practice what we see is a `Azure::Armrest::BadRequestException` raised in such cases, combined with a misleading error message from Azure. The error message suggests that it's simply a matter of adjusting the `api-version` string, but in reality none of them work if the region simply isn't supported.

Instead of raising an error, this PR adjusts the `MetricsCapture#get_counters` method to explicitly check for a `Azure::Armrest::BadRequestException`, logs a warning, and returns an empty array.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1645117
