### PR TITLE
Don't stub all_ems_in_zone

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb
@@ -3,8 +3,8 @@ describe ManageIQ::Providers::Azure::CloudManager::EventCatcher do
     let(:unsupported_reason) { "Timeline events not supported for this region" }
 
     before do
-      @ems = FactoryBot.create(:ems_azure)
-      allow(@ems).to receive(:authentication_status_ok?).and_return(true)
+      server = EvmSpecHelper.local_miq_server
+      @ems = FactoryGirl.create(:ems_azure, :with_authentication, :zone => server.zone)
       allow(described_class).to receive(:all_ems_in_zone).and_return([@ems])
     end
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb
@@ -5,18 +5,17 @@ describe ManageIQ::Providers::Azure::CloudManager::EventCatcher do
     before do
       server = EvmSpecHelper.local_miq_server
       @ems = FactoryGirl.create(:ems_azure, :with_authentication, :zone => server.zone)
-      allow(described_class).to receive(:all_ems_in_zone).and_return([@ems])
     end
 
     it "returns a valid ems for zone if timeline events are supported" do
-      allow(@ems).to receive(:supports_timeline?).and_return(true)
+      expect_any_instance_of(@ems.class).to receive(:supports_timeline?).and_return(true)
       expect($log).not_to receive(:info).with(/#{unsupported_reason}/)
       expect(described_class.all_valid_ems_in_zone).to include(@ems)
     end
 
     it "returns an empty list for zone if timeline events are not supported" do
-      allow(@ems).to receive(:supports_timeline?).and_return(false)
-      allow(@ems).to receive(:unsupported_reason).and_return(unsupported_reason)
+      expect_any_instance_of(@ems.class).to receive(:supports_timeline?).and_return(false)
+      expect_any_instance_of(@ems.class).to receive(:unsupported_reason).and_return(unsupported_reason)
       expect($log).to receive(:info).with(/#{unsupported_reason}/)
       expect(described_class.all_valid_ems_in_zone).not_to include(@ems)
     end


### PR DESCRIPTION
Depends on:
- [x] ManageIQ/manageiq#18266

I want to remove the `to_a` from `Ems#all_ems_in_zone`
So I'm removing the stub in the specs so the real `all_ems_in_zone` is called, tested and able to return a relation.


@miq-bot add_label tests