### PR TITLE
[WIP] Check for service support

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -50,6 +50,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
     @nsg = network_security_group_service(@config)
     @lbs = load_balancer_service(@config)
     @rts = route_table_service(@config)
+    @rps = cached_resource_provider_service(@config)
   end
 
   ##############################################################

--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -50,7 +50,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
     @nsg = network_security_group_service(@config)
     @lbs = load_balancer_service(@config)
     @rts = route_table_service(@config)
-    @rps = cached_resource_provider_service(@config)
+    @rps = resource_provider_service(@config)
   end
 
   ##############################################################

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -68,6 +68,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
   # their resource group.
   #
   def gather_data_for_this_region(arm_service, method_name = 'list_all')
+    return [] unless supported_service(arm_service.service_name)
     if method_name.to_s == 'list_all'
       arm_service.send(method_name).select do |resource|
         resource.try(:location).try(:casecmp, @ems.provider_region).zero?
@@ -82,6 +83,14 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
         end
       end.flatten
     end
+  end
+
+  # Caches a hash of services and their support status using the service name.
+  #
+  def supported_service(service_name)
+    @supported_service_hash ||= {}
+    return @supported_service_hash[service_name] unless @supported_service_hash[service_name].nil?
+    @supported_service_hash[service_name] = @rps.supported?(service_name)
   end
 
   # Because resources do not necessarily have to belong to the same region as

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -68,7 +68,11 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
   # their resource group.
   #
   def gather_data_for_this_region(arm_service, method_name = 'list_all')
-    return [] unless supported_service(arm_service.service_name)
+    unless supported_service(arm_service.service_name)
+      _log.warn("Skipping data collection for unsupported service: #{arm_service.service_name}")
+      return []
+    end
+
     if method_name.to_s == 'list_all'
       arm_service.send(method_name).select do |resource|
         resource.try(:location).try(:casecmp, @ems.provider_region).zero?

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -68,7 +68,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
   # their resource group.
   #
   def gather_data_for_this_region(arm_service, method_name = 'list_all')
-    unless supported_service(arm_service.service_name)
+    unless supported_service(arm_service)
       _log.warn("Skipping data collection for unsupported service: #{arm_service.service_name}")
       return []
     end
@@ -91,10 +91,10 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
 
   # Caches a hash of services and their support status using the service name.
   #
-  def supported_service(service_name)
+  def supported_service(arm_service)
     @supported_service_hash ||= {}
-    return @supported_service_hash[service_name] unless @supported_service_hash[service_name].nil?
-    @supported_service_hash[service_name] = @rps.supported?(service_name)
+    return @supported_service_hash[arm_service.service_name] unless @supported_service_hash[arm_service.service_name].nil?
+    @supported_service_hash[arm_service.service_name] = @rps.supported?(arm_service.service_name, arm_service.provider)
   end
 
   # Because resources do not necessarily have to belong to the same region as


### PR DESCRIPTION
Previously we were checking certain services for support, and then only in classic refresh. This PR takes a more generic approach for targeted refresh by modifying the `gather_data_for_this_region` method so that each service name is checked before attempting to collect data.

To keep the number of external REST API calls to a minimum, we use the cached resource provider service, and cache the results of each service check since it is extremely unlikely that the status of a service will change once it's set for a given instance. For such rare situations, the instance could be restarted.

WIP for now as I'm not sure if the cassettes will need to be regenerated.

https://bugzilla.redhat.com/show_bug.cgi?id=1566600