### PR TITLE
Remove references to MiqPassword

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision/options_helper.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/options_helper.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Azure::CloudManager::Provision::OptionsHelper
   def root_password
-    MiqPassword.decrypt(options[:root_password]) if options[:root_password]
+    ManageIQ::Password.decrypt(options[:root_password]) if options[:root_password]
   end
 
   def resource_group

--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -43,7 +43,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
       connection_rescue_block do
         ::Azure::Armrest::Configuration.new(
           :client_id       => client_id,
-          :client_key      => MiqPassword.try_decrypt(client_key),
+          :client_key      => ManageIQ::Password.try_decrypt(client_key),
           :tenant_id       => azure_tenant_id,
           :subscription_id => subscription,
           :proxy           => proxy_uri,
@@ -118,7 +118,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
       MiqQueue.put(
         :class_name  => name,
         :method_name => "discover_from_queue",
-        :args        => [clientid, MiqPassword.encrypt(clientkey), azure_tenant_id, subscription]
+        :args        => [clientid, ManageIQ::Password.encrypt(clientkey), azure_tenant_id, subscription]
       )
     end
 
@@ -128,7 +128,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
     end
 
     def discover_from_queue(clientid, clientkey, azure_tenant_id, subscription)
-      discover(clientid, MiqPassword.decrypt(clientkey), azure_tenant_id, subscription)
+      discover(clientid, ManageIQ::Password.decrypt(clientkey), azure_tenant_id, subscription)
     end
 
     def create_discovered_region(region_name, clientid, clientkey, azure_tenant_id, subscription, all_ems_names)

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
     it "decrypts passwords" do
       allow(::Azure::Armrest::Configuration).to receive(:new)
 
-      expect(MiqPassword).to receive(:try_decrypt).with("1234567890")
+      expect(ManageIQ::Password).to receive(:try_decrypt).with("1234567890")
       described_class.raw_connect("klmnopqrst", "1234567890", "abcdefghij", 'subscription', 'proxy_uri')
     end
   end


### PR DESCRIPTION
@agrare @djberg96 Please review.  This gets us closer to removing MiqPassword from manageiq-gems-pending.

cc @jrafanie 