### PR TITLE
Use string class name instead of hitting autoload

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager.rb
+++ b/app/models/manageiq/providers/azure/network_manager.rb
@@ -18,7 +18,7 @@ class ManageIQ::Providers::Azure::NetworkManager < ManageIQ::Providers::NetworkM
   include ManageIQ::Providers::Azure::ManagerMixin
 
   has_many :floating_ips, :foreign_key => :ems_id, :dependent => :destroy,
-           :class_name => ManageIQ::Providers::Azure::NetworkManager::FloatingIp
+           :class_name => "ManageIQ::Providers::Azure::NetworkManager::FloatingIp"
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled
   delegate :authentication_check,


### PR DESCRIPTION
Fixes a deprecation on rails 5.1:
DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies. Please pass the class name as a string: `has_many :floating_ips, class_name: 'ManageIQ::Providers::Azure::NetworkManager::FloatingIp'` (called from <class:NetworkManager> at /Users/joerafaniello/.gem/ruby/2.4.5/bundler/gems/manageiq-providers-azure-7d83a11a9ca9/app/models/manageiq/providers/azure/network_manager.rb:20)