### PR TITLE
Add a rubocop channel to the codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,6 +34,7 @@ engines:
   rubocop:
     enabled: true
     config: '.rubocop_cc.yml'
+    channel: 'rubocop-0-69'
 prepare:
   fetch:
   - url: "https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml"


### PR DESCRIPTION
See ManageIQ/manageiq#18840 for more information

Unfortunately there's no way to use a centralized .codeclimate, so we have to configure the configuration files individually.