### PR TITLE
fix wrong timestamp format

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -26,18 +26,7 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
     else
       _log.info("#{log_prefix} Caught event #{parse_event_type(event)} for #{event["resourceId"]}")
       event_hash = ManageIQ::Providers::Azure::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])
-
-      event_filter = {
-        :event_type => event_hash[:event_type],
-        :vm_ems_ref => event_hash[:vm_ems_ref],
-        :timestamp  => DateTime.parse(event_hash[:timestamp]),
-      }
-
-      if EmsEvent.where(event_filter).exists?
-        _log.info("#{log_prefix} Skipping duplicated Azure event #{event_hash[:event_type]} for #{event["resourceId"]}")
-      else
-        EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
-      end
+      EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
     end
   end
 

--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
@@ -40,7 +40,7 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream
   end
 
   def startup_interval
-    format_timestamp(5.minutes.ago)
+    format_timestamp(1.minute.ago)
   end
 
   def one_ms_from_last_timestamp(events)

--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
@@ -40,7 +40,7 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream
   end
 
   def startup_interval
-    (Time.current - 1.minute).httpdate
+    format_timestamp(5.minutes.ago)
   end
 
   def one_ms_from_last_timestamp(events)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1724312

Root issue was the wrond timestamp format in the first query to the Azure API since worker start.
Another potential issue could happen during that worker restart - if it lasts more than one minute. I extended it to 5 minutes and added a check to avoid duplicated events.