### PR TITLE
Set the vm_uid_ems in the event parser if it's a VM

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_parser.rb
@@ -18,7 +18,7 @@ module ManageIQ::Providers::Azure::CloudManager::EventParser
     }
 
     resource_type = event["resourceType"]["value"].to_s.downcase
-    event_hash[:vm_ems_ref] = parse_vm_ref(event) if resource_type == INSTANCE_TYPE
+    event_hash[:vm_uid_ems] = event_hash[:vm_ems_ref] = parse_vm_ref(event) if resource_type == INSTANCE_TYPE
 
     event_hash
   end

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_parser_spec.rb
@@ -23,7 +23,8 @@ describe ManageIQ::Providers::Azure::CloudManager::EventParser do
         :ems_id     => nil,
         :event_type => 'virtualMachines_deallocate_BeginRequest',
         :full_data  => event,
-        :vm_ems_ref => "xyz/bar/microsoft.compute/virtualmachines/another_vm"
+        :vm_ems_ref => "xyz/bar/microsoft.compute/virtualmachines/another_vm",
+        :vm_uid_ems => "xyz/bar/microsoft.compute/virtualmachines/another_vm"
       )
     end
 
@@ -38,7 +39,8 @@ describe ManageIQ::Providers::Azure::CloudManager::EventParser do
         :ems_id     => nil,
         :event_type => 'New Recommendation',
         :full_data  => event,
-        :vm_ems_ref => "xyz/foo/microsoft.compute/virtualmachines/my_vm1"
+        :vm_ems_ref => "xyz/foo/microsoft.compute/virtualmachines/my_vm1",
+        :vm_uid_ems => "xyz/foo/microsoft.compute/virtualmachines/my_vm1"
       )
     end
 
@@ -56,6 +58,7 @@ describe ManageIQ::Providers::Azure::CloudManager::EventParser do
       )
 
       expect(hash.key?(:vm_ems_ref)).to be(false)
+      expect(hash.key?(:vm_uid_ems)).to be(false)
     end
   end
 end


### PR DESCRIPTION
At the moment the Azure provider event parser loses track of its original VM in the case of a delete event. This affects timeline information.

The core `EmsEvent` class relies on the `vm_uid_ems` value to be set in order to preserve the original VM information:

https://github.com/ManageIQ/manageiq/blob/master/app/models/ems_event.rb#L87

Since the `vm_ems_ref` and `vm_uid_ems` are identical in the Azure provider, the solution was to simply assign the same value. In addition to the specs, I tried creating and deleting a couple VM's in the Azure dev environment and, after a few minutes, I could see the delete event with the `vm_or_template_id` and `vm_name` fields both set as expected.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1733384

Thanks go to @agrare for providing the solution.