### PR TITLE
Always return counters and counter_values

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/metrics_capture_spec.rb
@@ -24,28 +24,36 @@ describe ManageIQ::Providers::Azure::CloudManager::MetricsCapture do
 
     it "returns nothing if the insights service is not registered" do
       allow(ems).to receive(:insights?).and_return(false)
-      expect(metric.perf_collect_metrics('whatever')).to be_nil
+      counters, values = metric.perf_collect_metrics('whatever')
+      expect(counters).to eq({})
+      expect(values).to eq({})
     end
 
     it "returns nothing if the region is not supported" do
       allow(ems).to receive(:insights?).and_return(true)
       allow(armrest_service).to receive(:rest_get).and_raise(::Azure::Armrest::BadRequestException.new('x', 'y', 'z'))
       expect($log).to receive(:warn).with(/problem collecting metrics/i)
-      expect(metric.perf_collect_metrics('whatever')).to be_nil
+      counters, values = metric.perf_collect_metrics('whatever')
+      expect(counters).to eq({})
+      expect(values).to eq({})
     end
 
     it "returns nothing if a timeout occurs" do
       allow(ems).to receive(:insights?).and_return(true)
       allow(armrest_service).to receive(:rest_get).and_raise(::Azure::Armrest::RequestTimeoutException.new('x', 'y', 'z'))
       expect($log).to receive(:warn).with(/timeout attempting to collect metrics/i)
-      expect(metric.perf_collect_metrics('whatever')).to be_nil
+      counters, values = metric.perf_collect_metrics('whatever')
+      expect(counters).to eq({})
+      expect(values).to eq({})
     end
 
     it "returns nothing if the VM could not be found" do
       allow(ems).to receive(:insights?).and_return(true)
       allow(armrest_service).to receive(:rest_get).and_raise(::Azure::Armrest::NotFoundException.new('x', 'y', nil))
       expect($log).to receive(:warn).with(/could not find metrics for/i)
-      expect(metric.perf_collect_metrics('whatever')).to eql(nil)
+      counters, values = metric.perf_collect_metrics('whatever')
+      expect(counters).to eq({})
+      expect(values).to eq({})
     end
 
     it "raises an error if any other exception occurs" do


### PR DESCRIPTION
Always return two hashes from perf_capture_metrics because the calling
method expects it.

Catching an exception and logging the error without returning the proper
values leads to:
```
Problem collecting metrics for cu-24x7/Automation. Region [eastus2] may not be supported.
[NoMethodError]: undefined method `[]' for true:TrueClass
```

Now we'll just get the following

```
Problem collecting metrics for cu-24x7/Automation. Region [eastus2] may not be supported.
Capture for ManageIQ::Providers::Azure::CloudManager::Vm name: [cu-24x7], id: [17], start_time: [2019-08-23 00:00:00 UTC]...Complete
Skipping processing for ManageIQ::Providers::Azure::CloudManager::Vm name: [cu-24x7], id: [17], start_time: [2019-08-23 00:00:00 UTC] as no metrics were captured.
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1744845