### PR TITLE
fix undefined method issue

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -199,7 +199,7 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
 
         # add last minute's value
         ts, value = timestamped_values.to_a.last
-        counter_values.store_path(ts.iso8601, counter_info.counter_key, value)
+        counter_values.store_path(ts.iso8601, counter_info.counter_key, value) if ts
       end
     end
 


### PR DESCRIPTION
An error `NoMethodError (undefined method 'iso8601' for nil:NilClass)` can occur under some circumstances.