### PR TITLE
update_attributes has been deprecated

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
@@ -7,6 +7,6 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations
       raise _("VM has no %{table}, unable to destroy VM") % {:table => ui_lookup(:table => "ext_management_systems")}
     end
     provider_service.delete_associated_resources(name, resource_group.name)
-    update_attributes!(:raw_power_state => "Deleting")
+    update!(:raw_power_state => "Deleting")
   end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations::Power
 
   def raw_suspend
     provider_service.stop(name, resource_group.name)
-    update_attributes!(:raw_power_state => "VM stopping")
+    update!(:raw_power_state => "VM stopping")
   end
 
   def validate_pause
@@ -21,21 +21,21 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations::Power
 
   def raw_start
     provider_service.start(name, resource_group.name)
-    update_attributes!(:raw_power_state => "VM starting")
+    update!(:raw_power_state => "VM starting")
   end
 
   def raw_stop
     provider_service.deallocate(name, resource_group.name)
-    update_attributes!(:raw_power_state => "VM deallocating")
+    update!(:raw_power_state => "VM deallocating")
   end
 
   def raw_restart
     provider_service.restart(name, resource_group.name)
-    update_attributes!(:raw_power_state => "VM starting")
+    update!(:raw_power_state => "VM starting")
   end
 
   def reboot_guest
     provider_service.restart(name, resource_group.name)
-    update_attributes!(:raw_power_state => "VM starting")
+    update!(:raw_power_state => "VM starting")
   end
 end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -17,8 +17,8 @@ FactoryBot.define do
       }
 
       ems.authentications << FactoryBot.create(:authentication, cred)
-      ems.update_attributes(:azure_tenant_id => tenant_id)
-      ems.update_attributes(:subscription => subscription_id)
+      ems.update(:azure_tenant_id => tenant_id)
+      ems.update(:subscription => subscription_id)
     end
   end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -223,8 +223,8 @@ describe ManageIQ::Providers::Azure::CloudManager do
         :userid   => @client_id,
         :password => @client_key,
       }
-      ems.update_attributes(:azure_tenant_id => @tenant_id)
-      ems.update_attributes(:subscription => @subscription)
+      ems.update(:azure_tenant_id => @tenant_id)
+      ems.update(:subscription => @subscription)
       ems.authentications << FactoryBot.create(:authentication, cred)
     end
 


### PR DESCRIPTION
update_attributes and update_attributes! are deprecated starting in Rails 6.

See https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/ for details and Rails PR links.