### PR TITLE
Parse the Azure Event Timestamp into a DateTime

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
@@ -63,7 +63,10 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream
   def get_events
     filter = "eventTimestamp ge #{most_recent_time}"
     events = connection.list(:filter => filter, :select => SELECT_FIELDS, :all => true)
-    self.since = events.max_by(&:event_timestamp)&.event_timestamp
+
+    event_timestamp = events.max_by(&:event_timestamp)&.event_timestamp
+    self.since      = DateTime.strptime(event_timestamp, "%Y-%m-%dT%H:%M:%S.%L") if event_timestamp
+
     events
   end
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_catcher/stream_spec.rb
@@ -1,0 +1,23 @@
+describe ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream do
+  let(:ems) { FactoryBot.create(:ems_azure_with_authentication) }
+  let(:stream) { described_class.new(ems) }
+  let(:connection) { double("Azure::Armrest::Insights::EventService") }
+  before do
+    allow(stream).to receive(:create_event_service).and_return(connection)
+  end
+
+  context "#get_events (private)" do
+    let(:events) { [OpenStruct.new(:event_timestamp => "2019-09-30T11:20:00.0000000Z")] }
+    before do
+      allow(connection).to receive(:list).and_return(events)
+    end
+
+    context "first batch" do
+      it "parses the maximum timestamp and sets it to @since" do
+        stream.send(:get_events)
+
+        expect(stream.since.to_s).to eq("2019-09-30T11:20:00+00:00")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Azure event_timestamp is returned as a string which we then attempt
to do arithmatic on to get a relative time for subsequent queries.

We have to parse the timestamp into a DateTime object first before we
can do `- 2.minutes`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1756984