### PR TITLE
Remove checking for ems_ref_obj => nil

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -463,7 +463,6 @@ module AzureRefresherSpecCommon
     expect(vm).to have_attributes(
       :template              => false,
       :ems_ref               => vm_resource_id,
-      :ems_ref_obj           => nil,
       :uid_ems               => vm_resource_id,
       :vendor                => 'azure',
       :power_state           => 'on',
@@ -628,7 +627,6 @@ module AzureRefresherSpecCommon
     expect(vm).to have_attributes(
       :template              => false,
       :ems_ref               => vm_resource_id,
-      :ems_ref_obj           => nil,
       :uid_ems               => vm_resource_id,
       :vendor                => 'azure',
       :power_state           => 'off',
@@ -690,7 +688,6 @@ module AzureRefresherSpecCommon
     expect(template).to have_attributes(
       :template              => true,
       :ems_ref               => template_ems_ref,
-      :ems_ref_obj           => nil,
       :uid_ems               => template_ems_ref,
       :vendor                => 'azure',
       :power_state           => 'never',


### PR DESCRIPTION
The ems_ref_obj attribute is going to be removed in the near future,
also it isn't necessary to check that it is nil