### PR TITLE
Remove unused sub-manager refresh workers

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/azure/network_manager/refresh_worker.rb
@@ -1,7 +1,0 @@
-class ManageIQ::Providers::Azure::NetworkManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
-  def self.settings_name
-    :ems_refresh_worker_azure_network
-  end
-end

--- a/app/models/manageiq/providers/azure/network_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/azure/network_manager/refresh_worker/runner.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::Azure::NetworkManager::RefreshWorker::Runner < ManageIQ::Providers::BaseManager::RefreshWorker::Runner
-end


### PR DESCRIPTION
Refresh of the network manager is handled by the cloud manager
refresh worker

see also: https://github.com/ManageIQ/manageiq/pull/19524