### PR TITLE
Switch metric for disk data

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -34,8 +34,10 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
       :counter_key => 'disk_usage_rate_average', # TODO: should be 'disk_usage_absolute_average',
       :source      => :api,
       :metrics     => [
-        'Disk Read Bytes',
-        'Disk Write Bytes',
+        'OS Disk Read Bytes/sec',
+        'OS Disk Write Bytes/sec',
+        'Data Disk Read Bytes/sec',
+        'Data Disk Write Bytes/sec',
       ].freeze,
       :calculation => ->(stats) { stats.sum / 1.kilobyte },
       :unit_key    => 'kilobytespersecond',

--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -34,8 +34,8 @@ class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Provi
       :counter_key => 'disk_usage_rate_average', # TODO: should be 'disk_usage_absolute_average',
       :source      => :api,
       :metrics     => [
-        'Per Disk Read Bytes/sec',
-        'Per Disk Write Bytes/sec',
+        'Disk Read Bytes',
+        'Disk Write Bytes',
       ].freeze,
       :calculation => ->(stats) { stats.sum / 1.kilobyte },
       :unit_key    => 'kilobytespersecond',

--- a/spec/models/manageiq/providers/azure/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/metrics_capture_spec.rb
@@ -137,9 +137,8 @@ describe ManageIQ::Providers::Azure::CloudManager::MetricsCapture do
       expect(metrics_by_id_and_ts).to eq(expected_metrics)
     end
 
-    it "parses and aggregates read and write on disk" do
-      counters = stage_counter_data(['Per Disk Read Bytes/sec',
-                                     'Per Disk Write Bytes/sec'])
+    it "parses and aggregates read and write on disk", :disk do
+      counters = stage_counter_data(['Disk Read Bytes', 'Disk Write Bytes'])
 
       metric_data = [
         build_metric_data(982_252_000, "2016-07-23T07:20:00.5580968Z"),

--- a/spec/models/manageiq/providers/azure/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/metrics_capture_spec.rb
@@ -137,8 +137,13 @@ describe ManageIQ::Providers::Azure::CloudManager::MetricsCapture do
       expect(metrics_by_id_and_ts).to eq(expected_metrics)
     end
 
-    it "parses and aggregates read and write on disk", :disk do
-      counters = stage_counter_data(['Disk Read Bytes', 'Disk Write Bytes'])
+    it "parses and aggregates read and write on disk" do
+      counters = stage_counter_data([
+        'OS Disk Read Bytes/sec',
+        'OS Disk Write Bytes/sec',
+        'Data Disk Read Bytes/sec',
+        'Data Disk Write Bytes/sec',
+      ])
 
       metric_data = [
         build_metric_data(982_252_000, "2016-07-23T07:20:00.5580968Z"),


### PR DESCRIPTION
As per discussions with Nandini Chandra, I think we should switch the Azure metrics from "Per Disk Read/Write Bytes per sec" to just "Disk Read/Write Bytes". Partly this is because the current metrics doesn't really seem to collect much useful data, and partly because it's not even an option in the Azure portal's UI, and so isn't what a user would probably expect.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1780706