### PR TITLE
Delete attached data disks on vm destroy

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
@@ -6,7 +6,7 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations
     unless ext_management_system
       raise _("VM has no %{table}, unable to destroy VM") % {:table => ui_lookup(:table => "ext_management_systems")}
     end
-    provider_service.delete_associated_resources(name, resource_group.name)
+    provider_service.delete_associated_resources(name, resource_group.name, :data_disks => true)
     update!(:raw_power_state => "Deleting")
   end
 end

--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.9.13"
+  s.add_dependency "azure-armrest", "~>0.9.15"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This updates the `raw_destroy` method to delete associated data disks (in addition to the stuff it was already deleting).

This required updating the azure-armrest gem to 0.9.15.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1788053