### PR TITLE
Fix shadowed exceptions in Scanning::Job

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/scanning/job.rb
@@ -30,10 +30,6 @@ class ManageIQ::Providers::Azure::CloudManager::Scanning::Job < VmScan
       options[:use_existing_snapshot] = false
       return unless create_snapshot
       signal(:snapshot_complete)
-    rescue => err
-      _log.log_backtrace(err)
-      signal(:abort, err.message, "error")
-      return
     rescue Timeout::Error
       msg = case options[:snapshot]
             when :smartProxy, :skipped then "Request to log snapshot user event with EMS timed out."
@@ -41,6 +37,10 @@ class ManageIQ::Providers::Azure::CloudManager::Scanning::Job < VmScan
             end
       _log.error(msg)
       signal(:abort, msg, "error")
+    rescue => err
+      _log.log_backtrace(err)
+      signal(:abort, err.message, "error")
+      return
     end
   end
 
@@ -62,12 +62,12 @@ class ManageIQ::Providers::Azure::CloudManager::Scanning::Job < VmScan
         _log.info("Deleting snapshot: reference: [#{mor}]")
         begin
           delete_snapshot(mor)
-        rescue => err
-          _log.error(err.to_s)
-          return
         rescue Timeout::Error
           msg = "Request to delete snapshot timed out"
           _log.error(msg)
+        rescue => err
+          _log.error(err.to_s)
+          return
         end
 
         unless options[:snapshot] == :smartProxy


### PR DESCRIPTION
Codeclimate spotted these shadowed exceptions. The `TimeoutError` blocks will currently never be called since they're a subclass of `StandardError`. To see the current logic in action, run this:

```
require 'timeout'

begin
  raise Timeout::Error
rescue => err
  puts "REGULAR ERROR: #{err}"
rescue Timeout::Error => err
  puts "TIMEOUT ERROR: #{err}"
end

# RESULT => "REGULAR ERROR: Timeout::Error" # oops!
```
