### PR TITLE
Use symbols instead of strings for secrets config

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -6,10 +6,10 @@ FactoryBot.define do
     end
 
     after(:create) do |ems|
-      client_id       = Rails.application.secrets.azure.try(:[], 'client_id') || 'AZURE_CLIENT_ID'
-      client_key      = Rails.application.secrets.azure.try(:[], 'client_secret') || 'AZURE_CLIENT_SECRET'
-      tenant_id       = Rails.application.secrets.azure.try(:[], 'tenant_id') || 'AZURE_TENANT_ID'
-      subscription_id = Rails.application.secrets.azure.try(:[], 'subscription_id') || 'AZURE_SUBSCRIPTION_ID'
+      client_id       = Rails.application.secrets.azure.try(:[], :client_id) || 'AZURE_CLIENT_ID'
+      client_key      = Rails.application.secrets.azure.try(:[], :client_secret) || 'AZURE_CLIENT_SECRET'
+      tenant_id       = Rails.application.secrets.azure.try(:[], :tenant_id) || 'AZURE_TENANT_ID'
+      subscription_id = Rails.application.secrets.azure.try(:[], :subscription_id) || 'AZURE_SUBSCRIPTION_ID'
 
       cred = {
         :userid   => client_id,

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -170,10 +170,10 @@ describe ManageIQ::Providers::Azure::CloudManager do
     before do
       EvmSpecHelper.local_miq_server(:zone => Zone.seed)
 
-      @client_id    = Rails.application.secrets.azure.try(:[], 'client_id') || 'AZURE_CLIENT_ID'
-      @client_key   = Rails.application.secrets.azure.try(:[], 'client_secret') || 'AZURE_CLIENT_SECRET'
-      @tenant_id    = Rails.application.secrets.azure.try(:[], 'tenant_id') || 'AZURE_TENANT_ID'
-      @subscription = Rails.application.secrets.azure.try(:[], 'subscription_id') || 'AZURE_SUBSCRIPTION_ID'
+      @client_id    = Rails.application.secrets.azure.try(:[], :client_id) || 'AZURE_CLIENT_ID'
+      @client_key   = Rails.application.secrets.azure.try(:[], :client_secret) || 'AZURE_CLIENT_SECRET'
+      @tenant_id    = Rails.application.secrets.azure.try(:[], :tenant_id) || 'AZURE_TENANT_ID'
+      @subscription = Rails.application.secrets.azure.try(:[], :subscription_id) || 'AZURE_SUBSCRIPTION_ID'
 
       @alt_client_id    = 'testuser'
       @alt_client_key   = 'secret'


### PR DESCRIPTION
It seems we must use a symbol now to access Rails.application.secrets provider info.

I'm not sure when it changed, but futzing on the rails console confirms that this works:

`Rails.application.secrets.azure.try(:[], 'client_id') # nil`
vs
`Rails.application.secrets.azure.try(:[], :client_id) # stuff`

See also: ManageIQ/manageiq-providers-amazon#617