### PR TITLE
Loosen azure-armrest dependency to 0.9

### DIFF
--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.10"
+  s.add_dependency "azure-armrest", "~>0.9"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.9.15"
+  s.add_dependency "azure-armrest", "~>0.10.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/manageiq-providers-azure.gemspec
+++ b/manageiq-providers-azure.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "azure-armrest", "~>0.10.0"
+  s.add_dependency "azure-armrest", "~>0.10"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Version 0.10.0 of the azure-armrest gem includes an upgrade to rest-client-2.1.0, as well as azure-signature-0.3.0. It also updates a metrics collection method that was woefully out of date.

Update: Due to issues with other libraries conflicting with rest-client versions, I've changed this to just "0.9". Since I released 0.9.16 which loosens the rest-client dependency, this should work with either rest-client version.