### PR TITLE
Use vmId for uid_ems for instances

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -78,7 +78,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
       next if (status = collector.power_status(instance)).blank?
 
       persister_instance = persister.vms.build(
-        :uid_ems             => uid,
+        :uid_ems             => instance.properties.vm_id,
         :ems_ref             => uid,
         :name                => instance.name,
         :vendor              => "azure",

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -460,7 +460,7 @@ module AzureRefresherSpecCommon
     expect(vm).to have_attributes(
       :template              => false,
       :ems_ref               => vm_resource_id,
-      :uid_ems               => vm_resource_id,
+      :uid_ems               => '659e936f-a83c-4b87-9467-5393527d24d9',
       :vendor                => 'azure',
       :power_state           => 'on',
       :raw_power_state       => 'VM running',
@@ -624,7 +624,7 @@ module AzureRefresherSpecCommon
     expect(vm).to have_attributes(
       :template              => false,
       :ems_ref               => vm_resource_id,
-      :uid_ems               => vm_resource_id,
+      :uid_ems               => '1cdd5a0f-8aca-4e32-b24c-c2f25c7c60e0',
       :vendor                => 'azure',
       :power_state           => 'off',
       :location              => 'eastus',


### PR DESCRIPTION
Currently within the Azure provider the ems_ref and uid_ems are the same. This PR updates the code so that the uid_ems is set to the `vmId` property instead which is a guid string.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1846159