### PR TITLE
Mark the event monitor running before first event

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -10,8 +10,8 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
 
   def monitor_events
     event_monitor_handle.start
+    event_monitor_running
     event_monitor_handle.each_batch do |events|
-      event_monitor_running
       _log.debug("#{log_prefix} Received events #{events.collect { |e| parse_event_type(e) }}")
       @queue.enq(events)
       sleep_poll_normal


### PR DESCRIPTION
If we don't mark the event_monitor thread as running before the first event is delivered then the worker doesn't heartbeat and also won't shutdown cleanly.

Related to: https://github.com/ManageIQ/manageiq-providers-amazon/pull/633