### PR TITLE
Filter out cloud networks with no cloud subnets during provisioning

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
@@ -15,6 +15,19 @@ class ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow < ManageIQ::Pr
     resource_groups.each_with_object({}) { |rg, hash| hash[rg.id] = rg.name }
   end
 
+  def allowed_cloud_networks(_options = {})
+    source = load_ar_obj(get_source_vm)
+    ems = source.try(:ext_management_system)
+
+    if ems.present?
+      ems.cloud_networks.select{ |cn| cn.cloud_subnets.size > 0 }.each_with_object({}) do |cn, hash|
+        hash[cn.id] = "#{cn.name} (#{cn.cidr})"
+      end
+    else
+      {}
+    end
+  end
+
   def allowed_cloud_subnets(_options = {})
     src = resources_for_ui
     if (cn = CloudNetwork.find_by(:id => src[:cloud_network_id]))

--- a/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision_workflow.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow < ManageIQ::Pr
     ems = source.try(:ext_management_system)
 
     if ems.present?
-      ems.cloud_networks.select{ |cn| cn.cloud_subnets.size > 0 }.each_with_object({}) do |cn, hash|
+      ems.cloud_networks.distinct.joins(:cloud_subnets).where.not(:cloud_subnets => {:id => nil}).each_with_object({}) do |cn, hash|
         hash[cn.id] = "#{cn.name} (#{cn.cidr})"
       end
     else

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -186,8 +186,14 @@ describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
       end
 
       it "#allowed_cloud_networks without availability zone returns everything" do
+        FactoryBot.create(:cloud_subnet, :cloud_network => @cn2)
         cns = workflow.allowed_cloud_networks
         expect(cns.keys).to match_array [@cn1.id, @cn2.id]
+      end
+
+      it "#allowed_cloud_networks without subnet" do
+        cns = workflow.allowed_cloud_networks
+        expect(cns.keys).to match_array [@cn1.id]
       end
     end
   end


### PR DESCRIPTION
In Azure you cannot provision a VM with a vnet that doesn't have at least one subnet. So, this PR adjusts the provisioning screen so that it will filter out any virtual networks that don't have at least one attached subnet. 

Part of a solution to https://github.com/ManageIQ/manageiq-providers-azure/issues/375 (the other part being a modification on the automate side at https://github.com/ManageIQ/manageiq-content/pull/662).