### PR TITLE
Make the default credentials required in the provider DDF

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -66,6 +66,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
                 :id                     => 'authentications.default.valid',
                 :name                   => 'authentications.default.valid',
                 :skipSubmit             => true,
+                :isRequired             => true,
                 :validationDependencies => %w[type zone_id provider_region subscription uid_ems],
                 :fields                 => [
                   {


### PR DESCRIPTION
The default behavior for the `async-credentials` component is [changing to be optional](https://github.com/ManageIQ/manageiq-ui-classic/pull/7347), so it has to be explicitly marked as required here.