### PR TITLE
private_constant rubocop fix

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb
@@ -5,7 +5,7 @@
 class ManageIQ::Providers::Azure::CloudManager::MetricsCapture < ManageIQ::Providers::CloudManager::MetricsCapture
   INTERVAL_1_MINUTE = 'PT1M'
   VIM_INTERVAL = 20.seconds.freeze
-  private_constant(*%i[INTERVAL_1_MINUTE VIM_INTERVAL])
+  private_constant :INTERVAL_1_MINUTE, :VIM_INTERVAL
 
   COUNTERS_INFO = [
     ## CPU


### PR DESCRIPTION
Fixes a minor rubocop complaint picked up by the linter. Kind of a weird place to do a splat and this is more readable anyway IMO.