### PR TITLE
rubocop linter fixes

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -7,3 +7,5 @@ Naming/AccessorMethodName:
   Exclude:
     - app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
     - app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
+Lint/RescueException:
+  Enabled: false

--- a/app/models/manageiq/providers/azure/cloud_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/scanning/job.rb
@@ -127,7 +127,7 @@ class ManageIQ::Providers::Azure::CloudManager::Scanning::Job < VmScan
   def create_snapshot
     if vm.ext_management_system
       _log.info("Creating snapshot")
-      user_event = start_user_event_message
+      log_start_user_event_message
       options[:snapshot] = :server
       begin
         # TODO: should this be a vm method?


### PR DESCRIPTION
This PR addresses the remaining rubocop linter issues.

First, it disables the `Lint/RescueException` cop since we cannot change those without risking breakage.

Second, it addresses what was originally a useless assignment. It turned out it wasn't just a useless assignment, but what appears to be a message that was supposed to be logged, but wasn't *actually* being logged anywhere. The `start_user_event_message` just returns a string, but does nothing special with it.

Instead I'm pretty sure we want `log_start_user_event_message`. You can see the accompanying `log_end_user_event_message` at https://github.com/ManageIQ/manageiq-providers-azure/blob/master/app/models/manageiq/providers/azure/cloud_manager/scanning/job.rb#L83

See https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_scan.rb#L242-L256 for more info.

On a side note, it looks like there's a few other providers with the same issue.