### PR TITLE
Adjust empty/initial values for select fields in DDF schemas

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -31,13 +31,14 @@ module ManageIQ::Providers::Azure::ManagerMixin
       {
         :fields => [
           {
-            :component  => "select",
-            :id         => "provider_region",
-            :name       => "provider_region",
-            :label      => _("Region"),
-            :isRequired => true,
-            :validate   => [{:type => "required"}],
-            :options    => provider_region_options
+            :component    => "select",
+            :id           => "provider_region",
+            :name         => "provider_region",
+            :label        => _("Region"),
+            :isRequired   => true,
+            :validate     => [{:type => "required"}],
+            :includeEmpty => true,
+            :options      => provider_region_options
           },
           {
             :component  => "text-field",


### PR DESCRIPTION
Because carbon has four different dropdowns, the DDF schemas need to have explicit initialValue or includeEmpty settings in order to make the form validation work.

@miq-bot assign @agrare