### PR TITLE
Persist the Microsoft.Insights capability to the EMS#capabilities column

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -40,11 +40,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   # events nor metrics are supported for that EMS.
   #
   def insights?
-    require 'azure-armrest'
-    with_provider_connection do |conf|
-      rps = ::Azure::Armrest::ResourceProviderService.new(conf)
-      rps.get('Microsoft.Insights').registration_state.casecmp('registered').zero?
-    end
+    !!capabilities["insights"]
   end
 
   def ensure_network_manager

--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -11,7 +11,16 @@ module ManageIQ::Providers::Azure::ManagerMixin
   end
 
   def verify_credentials(_auth_type = nil, options = {})
-    connect(options)
+    conn = connect(options)
+
+    # Check if the Microsoft.Insights Resource Provider is registered.  If not then
+    # neither events nor metrics are supported.
+    ms_insights_service = ::Azure::Armrest::ResourceProviderService.new(conn).get('Microsoft.Insights')
+    capabilities["insights"] = ms_insights_service.registration_state.casecmp('registered').zero?
+
+    save! if changed?
+
+    true
   end
 
   module ClassMethods


### PR DESCRIPTION
Rather than perform an API call everytime we need to check if Microsoft.Insights is registered in this region we can save it to the EMS capabilities column during verify_credentials.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-schema/pull/559

Fixes https://github.com/ManageIQ/manageiq-providers-azure/issues/438