### PR TITLE
Cache availability check for 1 hour

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher.rb
@@ -1,12 +1,21 @@
 class ManageIQ::Providers::Azure::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
   require_nested :Runner
 
+  cache_with_timeout(:timeline_available, 1.hour) { Hash.new }
+
+  def self.timeline_available?(ems)
+    available = timeline_available[ems.id]
+    return available unless available.nil?
+
+    timeline_avaliable[ems.id] = ems.supports?(:timeline)
+  end
+
   # Override the superclass method in order to disable event collection for
   # providers that do not support it.
   #
   def self.all_valid_ems_in_zone
     super.select do |ems|
-      ems.supports?(:timeline).tap do |available|
+      timeline_available?(ems).tap do |available|
         _log.info(ems.unsupported_reason(:timeline) + " [#{ems.provider_region}]") unless available
       end
     end


### PR DESCRIPTION
This check ends up getting called once every 15 seconds by the
sync_workers loop, which is expensive considering it rarely changes.
This cache is a temporary fix to lighten the CPU load on the
orchestrator, where it runs, until such time as we can properly cache
the value in the database.

Partially fixes #438

@agrare Please review.