### PR TITLE
Handle binary chars in private images exception message

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
@@ -35,7 +35,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::CloudManager < ManageIQ:
   def images
     collect_inventory(:private_images) { gather_data_for_this_region(@sas, 'list_all_private_images') }
   rescue ::Azure::Armrest::ApiException => err
-    _log.warn("Unable to collect Azure private images for: [#{@ems.name}] - [#{@ems.id}]: #{err.message}")
+    _log.warn("Unable to collect Azure private images for: [#{@ems.name}] - [#{@ems.id}]: #{err.message.force_encoding("utf-8")}")
     []
   end
 


### PR DESCRIPTION
There is an exception message that contains an XML doc but starts with
some non-utf-8 characters which is causing the whole string encoding to
be ASCII 8-bit which Logger then fails to log.

```
xEF\xBB\xBF<?xml version=\"1.0\" encoding=\"utf-8\"?>
<Error><Code>TlsVersionNotPermitted</Code>...
```
Fixes https://github.com/ManageIQ/manageiq-providers-azure/issues/451