### PR TITLE
[KASPAROV] Replace authentication_status_ok? with provider_authentication_status_ok?

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::Azure::CloudManager::EventCatcher do
 
     before do
       @ems = FactoryBot.create(:ems_azure)
-      allow(@ems).to receive(:authentication_status_ok?).and_return(true)
+      allow(@ems).to receive(:provider_authentication_status_ok?).and_return(true)
       allow(described_class).to receive(:all_ems_in_zone).and_return([@ems])
     end
 


### PR DESCRIPTION
Kasparov specific version of https://github.com/ManageIQ/manageiq-providers-azure/pull/452 which cannot be backported due to the utilization of the new capabilities column

Depends:
- [x] https://github.com/ManageIQ/manageiq/pull/21198