### PR TITLE
Fix a couple rubocop issues missed in AKS ContainerManager

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/container_manager.rb
@@ -1,3 +1,3 @@
-class ManageIQ::Providers::Azure::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector::               ContainerManager
+class ManageIQ::Providers::Azure::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager
   require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/azure/inventory/collector/container_manager/watch_notice.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/container_manager/watch_notice.rb
@@ -1,2 +1,2 @@
-class ManageIQ::Providers::Azure::Inventory::Collector::ContainerManager::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Collector::  ContainerManager::WatchNotice
+class ManageIQ::Providers::Azure::Inventory::Collector::ContainerManager::WatchNotice < ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager::WatchNotice
 end

--- a/spec/models/manageiq/providers/azure/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/container_manager/refresher_spec.rb
@@ -70,12 +70,12 @@ describe ManageIQ::Providers::Azure::ContainerManager::Refresher do
   def assert_specific_container_service
     container_service = ems.container_services.find_by(:name => "kube-dns")
     expect(container_service).to have_attributes(
-      :ems_ref => "064c713f-6e88-4947-baf1-21f57a6b2902",
-      :name    => "kube-dns",
+      :ems_ref          => "064c713f-6e88-4947-baf1-21f57a6b2902",
+      :name             => "kube-dns",
       :resource_version => "450",
       :session_affinity => "None",
       :portal_ip        => "10.0.0.10",
-      :service_type     => "ClusterIP",
+      :service_type     => "ClusterIP"
     )
 
     expect(container_service.container_project.name).to eq("kube-system")


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-providers-azure/pull/468

Without miq-bot running I was relying on me noticing my editor warn me about issues which isn't nearly as effective :sweat_smile: 