### PR TITLE
[MORPHY] ResourceGroups should live under the CloudManager

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -7,6 +7,7 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   require_nested :MetricsCapture
   require_nested :MetricsCollectorWorker
   require_nested :RefreshWorker
+  require_nested :ResourceGroup
   require_nested :Refresher
   require_nested :Vm
   require_nested :Template

--- a/app/models/manageiq/providers/azure/cloud_manager/resource_group.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/resource_group.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Azure::CloudManager::ResourceGroup < ResourceGroup
+end

--- a/app/models/manageiq/providers/azure/inventory/persister.rb
+++ b/app/models/manageiq/providers/azure/inventory/persister.rb
@@ -39,6 +39,7 @@ class ManageIQ::Providers::Azure::Inventory::Persister < ManageIQ::Providers::In
        hardwares
        networks
        operating_systems
+       resource_groups
        miq_templates
        vm_and_template_labels
        vm_and_template_taggings
@@ -48,8 +49,6 @@ class ManageIQ::Providers::Azure::Inventory::Persister < ManageIQ::Providers::In
     end
 
     add_auth_key_pairs
-
-    add_resource_groups
 
     add_orchestration_stacks
 
@@ -96,13 +95,6 @@ class ManageIQ::Providers::Azure::Inventory::Persister < ManageIQ::Providers::In
   end
 
   # ------ IC provider specific definitions -------------------------
-
-  def add_resource_groups
-    add_cloud_collection(:resource_groups, {}, {:auto_inventory_attributes => false}) do |builder|
-      builder.add_properties(:model_class => ::ManageIQ::Providers::Azure::ResourceGroup)
-      builder.add_default_values(:ems_id => manager.id)
-    end
-  end
 
   def add_auth_key_pairs(extra_properties = {})
     add_cloud_collection(:auth_key_pairs, extra_properties) do |builder|

--- a/app/models/manageiq/providers/azure/resource_group.rb
+++ b/app/models/manageiq/providers/azure/resource_group.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::Azure::ResourceGroup < ResourceGroup
-end

--- a/spec/factories/resource_group.rb
+++ b/spec/factories/resource_group.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :azure_resource_group,
           :parent => :resource_group,
-          :class  => 'ManageIQ::Providers::Azure::ResourceGroup'
+          :class  => 'ManageIQ::Providers::Azure::CloudManager::ResourceGroup'
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager/resource_group_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/resource_group_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::Azure::ResourceGroup do
+describe ManageIQ::Providers::Azure::CloudManager::ResourceGroup do
   context 'inheritance' do
     it 'is a subclass of ResourceGroup' do
       expect(subject).to be_a_kind_of(ResourceGroup)


### PR DESCRIPTION
Backport of #457 and #455
Depends: https://github.com/ManageIQ/manageiq/pull/21200