### PR TITLE
[MORPHY] Fix bad ResourceGroup class name

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -855,7 +855,7 @@ module AzureRefresherSpecCommon
   end
 
   def assert_specific_cloud_database
-    resource_group = ManageIQ::Providers::Azure::CloudManager::ResourceGroup.find_by(:name => @misc_group)
+    resource_group = ManageIQ::Providers::Azure::ResourceGroup.find_by(:name => @misc_group)
 
     sql_cloud_database = ManageIQ::Providers::Azure::CloudManager::CloudDatabase.find_by(
       :ems_ref => "/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-misc-eastus/providers/Microsoft.Sql/servers/db-test/databases/miq-test"


### PR DESCRIPTION
When the cloud database work was merged ResourceGroups had been moved under the Azure::CloudManager but on morphy they are still under Azure

Introduced by 6a3b28a5e