### PR TITLE
Fix Azure SSA not deleting snapshot

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/scanning/job.rb
@@ -122,10 +122,10 @@ class ManageIQ::Providers::Azure::CloudManager::Scanning::Job < VmScan
   end
 
   # All other signals
-  alias_method :start_snapshot,  :call_snapshot_create
-  alias_method :snapshot_delete, :call_snapshot_delete
-  alias_method :abort_job,       :process_abort
-  alias_method :cancel,          :process_cancel
+  alias start_snapshot  call_snapshot_create
+  alias snapshot_delete call_snapshot_delete
+  alias abort_job       process_abort
+  alias cancel          process_cancel
 
   private
 

--- a/app/models/manageiq/providers/azure/cloud_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/scanning/job.rb
@@ -93,8 +93,8 @@ class ManageIQ::Providers::Azure::CloudManager::Scanning::Job < VmScan
   def process_cancel(*args)
     begin
       delete_snapshot_and_reset_snapshot_mor("canceling")
-      super
-      rescue => err
+    rescue => err
+      _log.warn(err)
       _log.log_backtrace(err)
     end
 
@@ -104,8 +104,8 @@ class ManageIQ::Providers::Azure::CloudManager::Scanning::Job < VmScan
   def process_abort(*args)
     begin
       delete_snapshot_and_reset_snapshot_mor("aborting")
-      super
     rescue => err
+      _log.warn(err)
       _log.log_backtrace(err)
     end
 
@@ -121,10 +121,11 @@ class ManageIQ::Providers::Azure::CloudManager::Scanning::Job < VmScan
     end
   end
 
-
   # All other signals
-  alias_method :start_snapshot,     :call_snapshot_create
-  alias_method :snapshot_delete,    :call_snapshot_delete
+  alias_method :start_snapshot,  :call_snapshot_create
+  alias_method :snapshot_delete, :call_snapshot_delete
+  alias_method :abort_job,       :process_abort
+  alias_method :cancel,          :process_cancel
 
   private
 

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb
@@ -14,7 +14,6 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
     ManageIQ::Providers::Azure::CloudManager::Scanning::Job
   end
 
-
   #
   # Adjustment Multiplier is 4 (i.e. 4 times the specified timeout)
   #
@@ -27,7 +26,7 @@ module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared::Scanning
   def perform_metadata_scan(ost)
     require 'MiqVm/miq_azure_vm'
 
-    vm_args = { :name => name }
+    vm_args = {:name => name}
     _log.debug("name: #{name} (template = #{template})")
     if template
       if managed_image?

--- a/spec/models/manageiq/providers/azure/cloud_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/scanning/job_spec.rb
@@ -1,0 +1,107 @@
+describe ManageIQ::Providers::Azure::CloudManager::Scanning::Job do
+  let(:user)    { FactoryBot.create(:user_with_group) }
+  let(:tenant)  { FactoryBot.create(:tenant) }
+  let(:ems)     { FactoryBot.create(:ems_azure, :tenant => tenant) }
+  let(:vm)      { FactoryBot.create(:vm_azure, :ext_management_system => ems, :evm_owner => user, :miq_group => user.current_group) }
+  let!(:server) { EvmSpecHelper.local_miq_server(:vm => vm) }
+
+  before { allow(MiqEventDefinition).to receive_messages(:find_by => true) }
+
+  context "#scan" do
+    before do
+      vm.scan
+      job_item = MiqQueue.find_by(:class_name => "MiqAeEngine", :method_name => "deliver")
+      job_item.delivered(*job_item.deliver)
+    end
+
+    let(:job) { described_class.first }
+
+    it "should start in state waiting_to_start" do
+      expect(job.state).to eq("waiting_to_start")
+    end
+
+    it "should start in a dispatch_status of pending" do
+      expect(job.dispatch_status).to eq("pending")
+    end
+
+    context "#start" do
+      it "should raise vm_scan_start for Vm" do
+        expect(MiqAeEvent).to receive(:raise_evm_event).with(
+          "vm_scan_start",
+          an_instance_of(ManageIQ::Providers::Azure::CloudManager::Vm),
+          an_instance_of(Hash),
+          an_instance_of(Hash)
+        )
+        job.start
+      end
+
+      it "queues before_scan" do
+        job.start
+        job_item = MiqQueue.find_by(:class_name => "MiqAeEngine", :method_name => "deliver")
+        job_item.delivered(*job_item.deliver)
+        expect(MiqQueue.last.method_name).to eq("signal")
+      end
+    end
+
+    describe "#call_scan" do
+      before do
+        job.miq_server_id = server.id
+        allow(VmOrTemplate).to receive(:find).with(vm.id).and_return(vm)
+        allow(MiqServer).to receive(:find).with(server.id).and_return(server)
+      end
+
+      it "calls #scan_metadata on target VM and as result " do
+        expect(vm).to receive(:scan_metadata)
+        job.call_scan
+      end
+
+      it "triggers adding MiqServer#scan_metada to MiqQueue" do
+        job.call_scan
+        queue_item = MiqQueue.where(:class_name => "MiqServer", :queue_name => "smartproxy").first
+        expect(server.id).to eq queue_item.instance_id
+        expect(queue_item.args[0].vm_guid).to eq vm.guid
+      end
+
+      it "updates job message" do
+        allow(vm).to receive(:scan_metadata)
+        job.call_scan
+        expect(job.message).to eq "Scanning for metadata from VM"
+      end
+
+      it "sends signal :abort if there is any error" do
+        allow(vm).to receive(:scan_metadata).and_raise("Any Error")
+        expect(job).to receive(:signal).with(:abort, any_args)
+        job.call_scan
+      end
+    end
+
+    describe "#call_synchronize" do
+      before do
+        job.miq_server_id = server.id
+        allow(VmOrTemplate).to receive(:find).with(vm.id).and_return(vm)
+        allow(MiqServer).to receive(:find).with(server.id).and_return(server)
+      end
+
+      it "calls VmOrTemlate#sync_metadata with correct parameters" do
+        expect(vm).to receive(:sync_metadata).with(any_args, "taskid" => job.jobid, "host" => server)
+        job.call_synchronize
+      end
+
+      it "sends signal :abort if there is any error" do
+        allow(vm).to receive(:sync_metadata).and_raise("Any Error")
+        expect(job).to receive(:signal).with(:abort, any_args)
+        job.call_synchronize
+      end
+
+      it "does not updates job status" do
+        expect(job).to receive(:set_status).with("Synchronizing metadata from VM")
+        job.call_synchronize
+      end
+
+      it "executes Job#dispatch_finish" do
+        expect(job).to receive(:dispatch_finish)
+        job.call_synchronize
+      end
+    end
+  end
+end


### PR DESCRIPTION
The snapshot context wasn't being set in the scan_args which caused an exception to be raised in `perform_metadata_scan` [[here]](https://github.com/ManageIQ/manageiq-providers-azure/blob/master/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared/scanning.rb#L43)

In addition the after_scan state was not implemented and thus the call_snapshot_delete state was never called.

TODO:
- [x] Clearly this needs some specs
- [x] The Azure override of `process_abort` isn't being called on failure leaving snapshots around

Fixes https://github.com/ManageIQ/manageiq/issues/21560
Fixes https://github.com/ManageIQ/manageiq-providers-azure/issues/479