### PR TITLE
Skip instances if we cannot find the flavor

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -70,6 +70,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
 
       # TODO(lsmola) we have a non lazy dependency, can we remove that?
       series = persister.flavors.find(instance.properties.hardware_profile.vm_size.downcase)
+      next if series.nil?
 
       rg_ems_ref = collector.get_resource_group_ems_ref(instance)
       parent_ref = collector.parent_ems_ref(instance)


### PR DESCRIPTION
The flavor (aka series) is required for setting the instance hardware and operating information.

Without the flavor we don't have enough information to build the vm record and we should skip it.