### PR TITLE
Don't allow logical regions to be selected

### DIFF
--- a/config/regions.yml
+++ b/config/regions.yml
@@ -1,13 +1,4 @@
 ---
-asia:
-  :name: asia
-  :description: Asia
-asiapacific:
-  :name: asiapacific
-  :description: Asia Pacific
-australia:
-  :name: australia
-  :description: Australia
 australiacentral:
   :name: australiacentral
   :description: Australia Central
@@ -20,18 +11,12 @@ australiaeast:
 australiasoutheast:
   :name: australiasoutheast
   :description: Australia Southeast
-brazil:
-  :name: brazil
-  :description: Brazil
 brazilsouth:
   :name: brazilsouth
   :description: Brazil South
 brazilsoutheast:
   :name: brazilsoutheast
   :description: Brazil Southeast
-canada:
-  :name: canada
-  :description: Canada
 canadacentral:
   :name: canadacentral
   :description: Canada Central
@@ -47,15 +32,9 @@ centralus:
 centraluseuap:
   :name: centraluseuap
   :description: Central US EUAP
-centralusstage:
-  :name: centralusstage
-  :description: Central US (Stage)
 eastasia:
   :name: eastasia
   :description: East Asia
-eastasiastage:
-  :name: eastasiastage
-  :description: East Asia (Stage)
 eastus:
   :name: eastus
   :description: East US
@@ -65,27 +44,12 @@ eastus2:
 eastus2euap:
   :name: eastus2euap
   :description: East US 2 EUAP
-eastus2stage:
-  :name: eastus2stage
-  :description: East US 2 (Stage)
-eastusstage:
-  :name: eastusstage
-  :description: East US (Stage)
-europe:
-  :name: europe
-  :description: Europe
-france:
-  :name: france
-  :description: France
 francecentral:
   :name: francecentral
   :description: France Central
 francesouth:
   :name: francesouth
   :description: France South
-germany:
-  :name: germany
-  :description: Germany
 germanycentral:
   :name: germanycentral
   :description: Germany Central
@@ -98,15 +62,6 @@ germanynortheast:
 germanywestcentral:
   :name: germanywestcentral
   :description: Germany West Central
-global:
-  :name: global
-  :description: Global
-india:
-  :name: india
-  :description: India
-japan:
-  :name: japan
-  :description: Japan
 japaneast:
   :name: japaneast
   :description: Japan East
@@ -119,9 +74,6 @@ jioindiacentral:
 jioindiawest:
   :name: jioindiawest
   :description: Jio India West
-korea:
-  :name: korea
-  :description: Korea
 koreacentral:
   :name: koreacentral
   :description: Korea Central
@@ -131,24 +83,15 @@ koreasouth:
 northcentralus:
   :name: northcentralus
   :description: North Central US
-northcentralusstage:
-  :name: northcentralusstage
-  :description: North Central US (Stage)
 northeurope:
   :name: northeurope
   :description: North Europe
-norway:
-  :name: norway
-  :description: Norway
 norwayeast:
   :name: norwayeast
   :description: Norway East
 norwaywest:
   :name: norwaywest
   :description: Norway West
-southafrica:
-  :name: southafrica
-  :description: South Africa
 southafricanorth:
   :name: southafricanorth
   :description: South Africa North
@@ -158,51 +101,33 @@ southafricawest:
 southcentralus:
   :name: southcentralus
   :description: South Central US
-southcentralusstage:
-  :name: southcentralusstage
-  :description: South Central US (Stage)
 southeastasia:
   :name: southeastasia
   :description: Southeast Asia
-southeastasiastage:
-  :name: southeastasiastage
-  :description: Southeast Asia (Stage)
 southindia:
   :name: southindia
   :description: South India
 swedencentral:
   :name: swedencentral
   :description: Sweden Central
-switzerland:
-  :name: switzerland
-  :description: Switzerland
 switzerlandnorth:
   :name: switzerlandnorth
   :description: Switzerland North
 switzerlandwest:
   :name: switzerlandwest
   :description: Switzerland West
-uae:
-  :name: uae
-  :description: United Arab Emirates
 uaecentral:
   :name: uaecentral
   :description: UAE Central
 uaenorth:
   :name: uaenorth
   :description: UAE North
-uk:
-  :name: uk
-  :description: United Kingdom
 uksouth:
   :name: uksouth
   :description: UK South
 ukwest:
   :name: ukwest
   :description: UK West
-unitedstates:
-  :name: unitedstates
-  :description: United States
 usgovarizona:
   :name: usgovarizona
   :description: US Gov Arizona
@@ -230,12 +155,6 @@ westus:
 westus2:
   :name: westus2
   :description: West US 2
-westus2stage:
-  :name: westus2stage
-  :description: West US 2 (Stage)
 westus3:
   :name: westus3
   :description: West US 3
-westusstage:
-  :name: westusstage
-  :description: West US (Stage)

--- a/lib/tasks_private/azure.rake
+++ b/lib/tasks_private/azure.rake
@@ -7,7 +7,6 @@ namespace :azure do
 
     desc "Update list of regions"
     task :update => :environment do
-      # Only physical regions (not logical regions) can be used
       regions = physical_regions.map do |region|
         {
           :name        => region["name"],
@@ -35,15 +34,12 @@ namespace :azure do
       ]
     end
 
-    def all_regions
-      stdout, status = Open3.capture2('az account list-locations')
+    def physical_regions
+      # Only physical regions (not logical regions) can be used
+      stdout, status = Open3.capture2("az account list-locations --query \"[?contains(metadata.regionType, 'Physical')]\"")
       raise status unless status.success?
 
       JSON.parse(stdout)
-    end
-
-    def physical_regions
-      all_regions.select { |region| region.dig("metadata", "regionType") == "Physical" }
     end
   end
 end


### PR DESCRIPTION
Logical regions are not able to be used for certain API calls, specifically getting a list of flavors which causes refresh to fail.

`MIQ(ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection#flavors) Error Class=Azure::Armrest::BadRequestException, Message=No registered resource provider found for location 'unitedstates' and API version '2021-11-01' for type 'locations/vmSizes'. The supported api-versions are '2015-05-01-preview, 2015-06-15, 2016-03-30, 2016-04-30-preview, 2016-08-30, 2017-03-30, 2017-12-01, 2018-04-01, 2018-06-01, 2018-10-01, 2019-03-01, 2019-07-01, 2019-12-01, 2020-06-01, 2020-12-01, 2021-03-01, 2021-04-01, 2021-07-01, 2021-11-01'. The supported locations are 'eastus, eastus2, westus, centralus, northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia, japaneast, japanwest, australiaeast, australiasoutheast, australiacentral, brazilsouth, southindia, centralindia, westindia, canadacentral, canadaeast, westus2, westcentralus, uksouth, ukwest, koreacentral, francecentral, southafricanorth, uaenorth, switzerlandnorth, germanywestcentral, norwayeast, jioindiawest, westus3, swedencentral, koreasouth'.`