### PR TITLE
Skip Azure regions with NULL physicalLocations

### DIFF
--- a/config/regions.yml
+++ b/config/regions.yml
@@ -29,9 +29,6 @@ centralindia:
 centralus:
   :name: centralus
   :description: Central US
-centraluseuap:
-  :name: centraluseuap
-  :description: Central US EUAP
 eastasia:
   :name: eastasia
   :description: East Asia
@@ -41,9 +38,6 @@ eastus:
 eastus2:
   :name: eastus2
   :description: East US 2
-eastus2euap:
-  :name: eastus2euap
-  :description: East US 2 EUAP
 francecentral:
   :name: francecentral
   :description: France Central

--- a/lib/tasks_private/azure.rake
+++ b/lib/tasks_private/azure.rake
@@ -36,7 +36,7 @@ namespace :azure do
 
     def physical_regions
       # Only physical regions (not logical regions) can be used
-      stdout, status = Open3.capture2("az account list-locations --query \"[?contains(metadata.regionType, 'Physical')]\"")
+      stdout, status = Open3.capture2("az account list-locations --query \"[?contains(metadata.regionType, 'Physical') && (metadata.physicalLocation!=null)]\"")
       raise status unless status.success?
 
       JSON.parse(stdout)


### PR DESCRIPTION
The two EUAP regions are physical regions that are "Early Updates Access Program" that are not valid selections for the VM service