### PR TITLE
Fix self.verify_credentials region nil

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -126,7 +126,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
     #   }
     # }
     def verify_credentials(args)
-      region           = args["region"]
+      region           = args["provider_region"]
       subscription     = args["subscription"]
       azure_tenant_id  = args["uid_ems"]
       default_endpoint = args.dig("authentications", "default")


### PR DESCRIPTION
The region information passed to the class-level verify_credentials method from the DDF forms is in `args["provider_region"]` not `args["region"]`.

With a `nil` region you would see a `WARN -- azure: No region selected. Validating credentials against public environment.` warning in the logs and we would not verify credentials against the region selected.