### PR TITLE
Use supports?(:event) for all_valid_ems_in_zone

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -36,6 +36,12 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
   end
 
   supports :label_mapping
+
+  supports :events do
+    unless insights?
+      unsupported_reason_add(:events, _('Events are not supported for this region'))
+    end
+  end
   supports :metrics do
     unless insights?
       unsupported_reason_add(:metrics, _('Capacity & Utilization not supported for this region'))

--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher.rb
@@ -5,10 +5,6 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher < ManageIQ::Provide
   # providers that do not support it.
   #
   def self.all_valid_ems_in_zone
-    super.select do |ems|
-      ems.supports?(:timeline).tap do |available|
-        _log.info(ems.unsupported_reason(:timeline) + " [#{ems.provider_region}]") unless available
-      end
-    end
+    super.select { |ems| ems.supports?(:events) }
   end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb
@@ -8,7 +8,6 @@ describe ManageIQ::Providers::Azure::CloudManager::EventCatcher do
       let(:insights) { true }
 
       it "returns a valid ems for zone if timeline events are supported" do
-        expect($log).not_to receive(:info).with(/#{unsupported_reason}/)
         expect(described_class.all_valid_ems_in_zone).to include(ems)
       end
     end
@@ -17,7 +16,6 @@ describe ManageIQ::Providers::Azure::CloudManager::EventCatcher do
       let(:insights) { false }
 
       it "returns an empty list for zone if timeline events are not supported" do
-        expect($log).to receive(:info).with(/#{unsupported_reason}/)
         expect(described_class.all_valid_ems_in_zone).not_to include(ems)
       end
     end


### PR DESCRIPTION
The `:events` feature has been added to core in https://github.com/ManageIQ/manageiq/pull/21780 so we can be more specific with the event that we check here