### PR TITLE
Fix access to Germany regions

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -201,8 +201,6 @@ module ManageIQ::Providers::Azure::ManagerMixin
 
     def environment_for(region)
       case region
-      when /germany/i
-        ::Azure::Armrest::Environment::Germany
       when /usgov/i
         ::Azure::Armrest::Environment::USGovernment
       else


### PR DESCRIPTION
The Germany specific active directory environment has been replaced by the standard Public environment.