### PR TITLE
Add connect service options

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/cloud_database.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/cloud_database.rb
@@ -44,13 +44,13 @@ class ManageIQ::Providers::Azure::CloudManager::CloudDatabase < ::CloudDatabase
   def self.raw_create_cloud_database(ext_management_system, options)
     case options[:database]
     when 'SQL'
-      db_client = get_sql_db_client(ext_management_system)
+      db_client = ext_management_system.connect(:service => "SqlDatabaseService")
     when 'MySQL'
-      db_client = get_mysql_db_client(ext_management_system)
+      db_client = ext_management_system.connect(:service => "MysqlDatabaseService")
     when 'PostgreSQL'
-      db_client = get_postgresql_db_client(ext_management_system)
+      db_client = ext_management_system.connect(:service => "PostgresqlDatabaseService")
     when 'MariaDB'
-      db_client = get_mariadb_db_client(ext_management_system)
+      db_client = ext_management_system.connect(:service => "MariadbDatabaseService")
     else
       raise ArgumentError, _("Invalid database type")
     end
@@ -64,40 +64,16 @@ class ManageIQ::Providers::Azure::CloudManager::CloudDatabase < ::CloudDatabase
   def raw_delete_cloud_database
     case db_engine
     when /SQL Server/
-      self.class.get_sql_db_client(ext_management_system).delete_by_id(ems_ref)
+      ext_management_system.connect(:service => "SqlDatabaseService").delete_by_id(ems_ref)
     when /MariaDB/
-      self.class.get_mariadb_db_client(ext_management_system).delete_by_id(ems_ref)
+      ext_management_system.connect(:service => "MariadbDatabaseService").delete_by_id(ems_ref)
     when /MySQL/
-      self.class.get_mysql_db_client(ext_management_system).delete_by_id(ems_ref)
+      ext_management_system.connect(:service => "MysqlDatabaseService").delete_by_id(ems_ref)
     when /PostgreSQL/
-      self.class.get_postgresql_db_client(ext_management_system).delete_by_id(ems_ref)
+      ext_management_system.connect(:service => "PostgresqlDatabaseService").delete_by_id(ems_ref)
     end
   rescue => err
     _log.error("cloud database=[#{name}], error: #{err}")
     raise
-  end
-
-  def self.get_sql_db_client(ems)
-    require 'azure-armrest'
-
-    ::Azure::Armrest::Sql::SqlDatabaseService.new(ems.connect)
-  end
-
-  def self.get_mysql_db_client(ems)
-    require 'azure-armrest'
-
-    ::Azure::Armrest::Sql::MysqlDatabaseService.new(ems.connect)
-  end
-
-  def self.get_postgresql_db_client(ems)
-    require 'azure-armrest'
-
-    ::Azure::Armrest::Sql::PostgresqlDatabaseService.new(ems.connect)
-  end
-
-  def self.get_mariadb_db_client(ems)
-    require 'azure-armrest'
-
-    ::Azure::Armrest::Sql::MariadbDatabaseService.new(ems.connect)
   end
 end

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -334,7 +334,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     @network_ports_cache ||= if refs.size > record_limit
                                set = Set.new(refs)
-                               collect_inventory(:network_ports) { @network_ports_cache ||= network_interfaces }.select do |network_port|
+                               collect_inventory(:network_ports) { @network_ports_cache ||= get_network_interfaces }.select do |network_port|
                                  set.include?(network_port.id)
                                end
                              else

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -75,7 +75,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     elsif method_name.to_s == 'list_all_private_images' # requires special handling
       arm_service.send(method_name, :location => @ems.provider_region)
     else
-      resource_groups.collect do |resource_group|
+      get_resource_groups.collect do |resource_group|
         arm_service.send(method_name, resource_group.name).select do |resource|
           location = resource.respond_to?(:location) ? resource.location : resource_group.location
           location.casecmp(@ems.provider_region).zero?
@@ -87,7 +87,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
   # Because resources do not necessarily have to belong to the same region as
   # the resource group they live in, we do not filter by region here.
   #
-  def resource_groups
+  def get_resource_groups
     @resource_groups ||= @rgs.list(:all => true)
   end
 
@@ -103,7 +103,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     network_interfaces.find_all { |nic| nic_ids.include?(nic.id) }
   end
 
-  def network_interfaces
+  def get_network_interfaces
     @network_interfaces ||= gather_data_for_this_region(@nis)
   end
 
@@ -111,7 +111,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     @ip_addresses ||= gather_data_for_this_region(@ips)
   end
 
-  def network_routers
+  def get_network_routers
     @network_routers ||= gather_data_for_this_region(@rts)
   end
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/cloud_database_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/cloud_database_spec.rb
@@ -13,17 +13,13 @@ describe ManageIQ::Providers::Azure::CloudManager::CloudDatabase do
     double(":Azure::Armrest::Configuration")
   end
 
-  before do
-    allow(ems).to receive(:connect).and_return(config)
-  end
-
   describe 'sql database actions' do
     let(:db_client) do
       double("::Azure::Armrest::Sql::SqlDatabaseService")
     end
 
     before do
-      allow(::Azure::Armrest::Sql::SqlDatabaseService).to receive(:new).with(config).and_return(db_client)
+      allow(ems).to receive(:connect).and_return(db_client)
     end
 
     it 'creates a SQL database' do
@@ -47,7 +43,7 @@ describe ManageIQ::Providers::Azure::CloudManager::CloudDatabase do
     end
 
     before do
-      allow(::Azure::Armrest::Sql::MariadbDatabaseService).to receive(:new).with(config).and_return(db_client)
+      allow(ems).to receive(:connect).and_return(db_client)
     end
 
     it 'creates a MariaDB database' do
@@ -71,7 +67,7 @@ describe ManageIQ::Providers::Azure::CloudManager::CloudDatabase do
     end
 
     before do
-      allow(::Azure::Armrest::Sql::MysqlDatabaseService).to receive(:new).with(config).and_return(db_client)
+      allow(ems).to receive(:connect).and_return(db_client)
     end
 
     it 'creates a MySQL database' do
@@ -95,7 +91,7 @@ describe ManageIQ::Providers::Azure::CloudManager::CloudDatabase do
     end
 
     before do
-      allow(::Azure::Armrest::Sql::PostgresqlDatabaseService).to receive(:new).with(config).and_return(db_client)
+      allow(ems).to receive(:connect).and_return(db_client)
     end
 
     it 'creates a PostgreSQL database' do

--- a/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager_spec.rb
@@ -113,7 +113,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
         proxy = 'http://www.foo.bar'
         allow(@e).to receive(:http_proxy_uri).and_return(proxy)
 
-        expect(described_class).to receive(:raw_connect) do |_id, _key, _tenant, _sub, http_proxy_uri|
+        expect(described_class).to receive(:raw_connect) do |_id, _key, _tenant, _sub, _service, http_proxy_uri|
           expect(http_proxy_uri).to eq(proxy)
         end
 
@@ -121,7 +121,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
       end
 
       it "with provider_region" do
-        expect(described_class).to receive(:raw_connect) do |_id, _key, _tenant, _sub, _proxy, provider_region|
+        expect(described_class).to receive(:raw_connect) do |_id, _key, _tenant, _sub, _service, _proxy, provider_region|
           expect(provider_region).to eq("westus2")
         end
 
@@ -133,7 +133,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
         endpoint = Endpoint.new(:url => 'http://www.foo.bar', :hostname => 'www.foo.bar', :path => '/')
         allow(@e).to receive(:default_endpoint).and_return(endpoint)
 
-        expect(described_class).to receive(:raw_connect) do |_id, _key, _tenant, _sub, _proxy, _region, default_endpoint|
+        expect(described_class).to receive(:raw_connect) do |_id, _key, _tenant, _sub, _service, _proxy, _region, default_endpoint|
           expect(default_endpoint.url).to eq('http://www.foo.bar')
           expect(default_endpoint.hostname).to eq('www.foo.bar')
           expect(default_endpoint.path).to eq('/')
@@ -146,7 +146,7 @@ describe ManageIQ::Providers::Azure::CloudManager do
         endpoint = Endpoint.new(:url => 'http://www.foo.bar/some/path', :hostname => 'www.foo.bar', :path => '/some/path')
         allow(@e).to receive(:default_endpoint).and_return(endpoint)
 
-        expect(described_class).to receive(:raw_connect) do |_id, _key, _tenant, _sub, _proxy, _region, default_endpoint|
+        expect(described_class).to receive(:raw_connect) do |_id, _key, _tenant, _sub, _service, _proxy, _region, default_endpoint|
           expect(default_endpoint.url).to eq('http://www.foo.bar/some/path')
           expect(default_endpoint.hostname).to eq('www.foo.bar')
           expect(default_endpoint.path).to eq('/some/path')


### PR DESCRIPTION
- can connect to service clients using `ems.connect(:service => service_name)` as opposed to directly using `RefreshHelperMethods`
- adjusted spec tests to accommodate change, cloud database CRUD operations will now use this

Todo (follow-up PR): refactor `RefreshHelperMethods` and move to manager_mixin

@miq-bot add_label enhancement
@miq-bot assign @agrare 