### PR TITLE
Delegate NetworkManager refresh to CloudManager

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager.rb
+++ b/app/models/manageiq/providers/azure/network_manager.rb
@@ -33,6 +33,8 @@ class ManageIQ::Providers::Azure::NetworkManager < ManageIQ::Providers::NetworkM
            :default_endpoint,
            :endpoints,
            :azure_tenant_id,
+           :refresh_ems,
+           :refresh,
            :to        => :parent_manager,
            :allow_nil => true
 


### PR DESCRIPTION
Azure technically doesn't have the same bug as VPC since there is no storage manager and thus `manager or manager.network_manager` works, but still this is the direction we want to go in but not need to backport this