### PR TITLE
Updating Create Cloud Database

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/cloud_database_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/cloud_database_spec.rb
@@ -24,10 +24,10 @@ describe ManageIQ::Providers::Azure::CloudManager::CloudDatabase do
 
     it 'creates a SQL database' do
       expect(db_client).to receive(:create).with("test-server", cloud_database.name, "test-group", {:location => ems.provider_region})
-      cloud_database.class.raw_create_cloud_database(ems, {:name           => cloud_database.name,
-                                                           :server         => "test-server",
-                                                           :database       => "SQL",
-                                                           :resource_group => "test-group"})
+      cloud_database.class.raw_create_cloud_database(ems, {"name"           => cloud_database.name,
+                                                           "server"         => "test-server",
+                                                           "database"       => "SQL",
+                                                           "resource_group" => "test-group"})
     end
 
     it 'delete a SQL database' do
@@ -48,10 +48,10 @@ describe ManageIQ::Providers::Azure::CloudManager::CloudDatabase do
 
     it 'creates a MariaDB database' do
       expect(db_client).to receive(:create).with("test-server", cloud_database.name, "test-group", {:location => ems.provider_region})
-      cloud_database.class.raw_create_cloud_database(ems, {:name           => cloud_database.name,
-                                                           :server         => "test-server",
-                                                           :database       => "MariaDB",
-                                                           :resource_group => "test-group"})
+      cloud_database.class.raw_create_cloud_database(ems, {"name"           => cloud_database.name,
+                                                           "server"         => "test-server",
+                                                           "database"       => "MariaDB",
+                                                           "resource_group" => "test-group"})
     end
 
     it 'delete a MariaDB database' do
@@ -72,10 +72,10 @@ describe ManageIQ::Providers::Azure::CloudManager::CloudDatabase do
 
     it 'creates a MySQL database' do
       expect(db_client).to receive(:create).with("test-server", cloud_database.name, "test-group", {:location => ems.provider_region})
-      cloud_database.class.raw_create_cloud_database(ems, {:name           => cloud_database.name,
-                                                           :server         => "test-server",
-                                                           :database       => "MySQL",
-                                                           :resource_group => "test-group"})
+      cloud_database.class.raw_create_cloud_database(ems, {"name"           => cloud_database.name,
+                                                           "server"         => "test-server",
+                                                           "database"       => "MySQL",
+                                                           "resource_group" => "test-group"})
     end
 
     it 'delete a MySQL database' do
@@ -96,10 +96,10 @@ describe ManageIQ::Providers::Azure::CloudManager::CloudDatabase do
 
     it 'creates a PostgreSQL database' do
       expect(db_client).to receive(:create).with("test-server", cloud_database.name, "test-group", {:location => ems.provider_region})
-      cloud_database.class.raw_create_cloud_database(ems, {:name           => cloud_database.name,
-                                                           :server         => "test-server",
-                                                           :database       => "PostgreSQL",
-                                                           :resource_group => "test-group"})
+      cloud_database.class.raw_create_cloud_database(ems, {"name"           => cloud_database.name,
+                                                           "server"         => "test-server",
+                                                           "database"       => "PostgreSQL",
+                                                           "resource_group" => "test-group"})
     end
 
     it 'delete a PostgreSQL database' do


### PR DESCRIPTION
During testing for https://github.com/ManageIQ/manageiq-ui-classic/pull/8339 we found that all of these schema fields were needed to create a database. Additionally, `options` was expecting keys when we are passing in strings so that is also fixed here.