### PR TITLE
Cloud database servers refresh support

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManager
   require_nested :AvailabilityZone
   require_nested :CloudDatabase
+  require_nested :CloudDatabaseServer
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :Flavor

--- a/app/models/manageiq/providers/azure/cloud_manager/cloud_database_server.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/cloud_database_server.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Azure::CloudManager::CloudDatabaseServer < ::CloudDatabaseServer
+end

--- a/app/models/manageiq/providers/azure/inventory/persister.rb
+++ b/app/models/manageiq/providers/azure/inventory/persister.rb
@@ -34,6 +34,7 @@ class ManageIQ::Providers::Azure::Inventory::Persister < ManageIQ::Providers::In
   def initialize_cloud_inventory_collections
     %i(availability_zones
        cloud_databases
+       cloud_database_servers
        disks
        flavors
        hardwares


### PR DESCRIPTION
i.e.
```
 #<ManageIQ::Providers::Azure::CloudManager::CloudDatabaseServer:0x00007febc4205f78
  id: 9,
  name: "miq-sql-server",
  ems_ref:
   "/subscriptions/2b01dec2-6684-4f25-abfc-a2453e0ae52f/resourceGroups/test-group/providers/Microsoft.Sql/servers/miq-sql-server",
  ems_id: 15,
  server_type: "SQL",
  region: "East US",
  status: "Ready",
  version: "12.0",
  resource_group_id: 6>,
```

Dependent:
- [x] https://github.com/ManageIQ/manageiq/pull/21977
- [x] https://github.com/ManageIQ/manageiq-schema/pull/653

@miq-bot assign @agrare 
@miq-bot add_label enhancement