### PR TITLE
Fix `can't cast hash` error during provisioning

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
@@ -21,30 +21,6 @@ describe ManageIQ::Providers::Azure::CloudManager::Provision do
       allow(subject).to receive(:create_nic).and_return(nic_id)
     end
 
-    context "#find_destination_in_vmdb" do
-      vm_uid_hash = {
-        :subscription_id => subscription_id,
-        :resource_group  => resource_group,
-        :type            => type,
-        :name            => name
-      }
-      it "VM in same sub-class" do
-        vm_uid_hash[:subscription_id] = subscription_id
-        vm
-        expect(subject.find_destination_in_vmdb(vm_uid_hash)).to eq(vm)
-      end
-
-      it "VM in same sub-class with invalid parameters" do
-        vm_uid_hash[:subscription_id] = "invalid_subscription_id"
-        expect(subject.find_destination_in_vmdb(vm_uid_hash)).to be_nil
-      end
-
-      it "VM in different sub-class" do
-        vm = FactoryBot.create(:vm_openstack, :ext_management_system => provider)
-        expect(subject.find_destination_in_vmdb(:ems_ref => vm.ems_ref)).to be_nil
-      end
-    end
-
     context "#validate_dest_name" do
       let(:vm) { FactoryBot.create(:vm_azure, :ext_management_system => provider) }
 


### PR DESCRIPTION
When provisioning an instance a targeted refresh is queued using the value returned by the `start_clone` method as the `:ems_ref`.

Azure had been returning a hash rather than a string which was causing the Refresher to fail when querying for existing records using this hash as the `:ems_ref`.

The solution is to simply build the ems_ref the same way the Azure refresher does by joining the subscription, resource_group, type, and vm name.

Fixes https://github.com/ManageIQ/manageiq-providers-azure/issues/400
Fixes https://github.com/ManageIQ/manageiq/issues/21965