### PR TITLE
Use lazy_find :key to replace a direct `find()`

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -229,7 +229,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
   end
 
   def flavors
-    collect_inventory(:series) do
+    @flavors ||= collect_inventory(:series) do
       begin
         @vmm.series(@ems.provider_region)
       rescue ::Azure::Armrest::BadGatewayException, ::Azure::Armrest::GatewayTimeoutException,
@@ -238,6 +238,10 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
         []
       end
     end
+  end
+
+  def flavors_by_name
+    @flavors_by_name ||= flavors.index_by(&:name)
   end
 
   def availability_zones

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -47,16 +47,18 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
   def flavors
     refs = references(:flavors)
-
     return [] if refs.blank?
-    set = Set.new(refs)
 
-    collect_inventory_targeted(:series) { @vmm.series(@ems.provider_region) }.select do |flavor|
-      set.include?(flavor.name.downcase) # ems_ref is downcased flavor name
+    @flavors ||= begin
+      set = Set.new(refs)
+
+      collect_inventory_targeted(:series) { @vmm.series(@ems.provider_region) }.select do |flavor|
+        set.include?(flavor.name.downcase) # ems_ref is downcased flavor name
+      end
+    rescue ::Azure::Armrest::Exception => err
+      _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+      []
     end
-  rescue ::Azure::Armrest::Exception => err
-    _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
-    []
   end
 
   def availability_zones


### PR DESCRIPTION
Rather than use a direct `.find()` which introduces ordering issues use the `:key` feature of lazy_find to get the `:device` after the lazy_find is evaluated