### PR TITLE
Remove useless gather_data_for_this_region method

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -104,15 +104,15 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
   end
 
   def network_ports
-    @network_interfaces ||= collect_inventory(:network_ports) { gather_data_for_this_region(@nis) }
+    @network_interfaces ||= collect_inventory(:network_ports) { filter_my_region(@nis.list_all) }
   end
 
   def network_routers
-    @network_routers ||= collect_inventory(:network_routers) { gather_data_for_this_region(@rts) }
+    @network_routers ||= collect_inventory(:network_routers) { filter_my_region(@rts.list_all) }
   end
 
   def floating_ips
-    @floating_ips ||= collect_inventory(:floating_ips) { gather_data_for_this_region(@ips) }
+    @floating_ips ||= collect_inventory(:floating_ips) { filter_my_region(@ips.list_all) }
   end
 
   def instance_network_ports(instance)
@@ -249,7 +249,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
   end
 
   def instances
-    @instances_cache ||= collect_inventory(:instances) { gather_data_for_this_region(@vmm) }
+    @instances_cache ||= collect_inventory(:instances) { filter_my_region(@vmm.list_all) }
 
     instances_power_state_advanced_caching(@instances_cache) unless @instances_advanced_caching_done
     @instances_advanced_caching_done = true
@@ -262,14 +262,14 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
   # that it doesn't affect the rest of inventory collection.
   #
   def images
-    collect_inventory(:private_images) { gather_data_for_this_region(@sas, 'list_all_private_images') }
+    collect_inventory(:private_images) { @sas.list_all_private_images(:location => @ems.provider_region) }
   rescue ::Azure::Armrest::ApiException => err
     _log.warn("Unable to collect Azure private images for: [#{@ems.name}] - [#{@ems.id}]: #{err.message}")
     []
   end
 
   def managed_images
-    collect_inventory(:managed_images) { gather_data_for_this_region(@mis) }
+    collect_inventory(:managed_images) { filter_my_region(@mis.list_all) }
   end
 
   # Collect marketplace image information if configured to do so. Normally
@@ -295,16 +295,16 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
         )
       end
     else
-      gather_data_for_this_region(@vmis)
+      filter_my_region(@vmis.list_all)
     end
   end
 
   def cloud_networks
-    gather_data_for_this_region(@vns)
+    filter_my_region(@vns.list_all)
   end
 
   def security_groups
-    gather_data_for_this_region(@nsg)
+    filter_my_region(@nsg.list_all)
   end
 
   def sql_servers
@@ -323,7 +323,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
   end
 
   def mariadb_servers
-    @mariadb_servers ||= gather_data_for_this_region(@marias)
+    @mariadb_servers ||= filter_my_region(@marias.list_all)
   end
 
   def mariadb_databases
@@ -333,7 +333,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
   end
 
   def mysql_servers
-    @mysql_servers ||= gather_data_for_this_region(@mysqls)
+    @mysql_servers ||= filter_my_region(@mysqls.list_all)
   end
 
   def mysql_databases
@@ -343,7 +343,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
   end
 
   def postgresql_servers
-    @postgresql_servers ||= gather_data_for_this_region(@pgs)
+    @postgresql_servers ||= filter_my_region(@pgs.list_all)
   end
 
   def postgresql_databases
@@ -353,7 +353,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
   end
 
   def load_balancers
-    @load_balancers ||= gather_data_for_this_region(@lbs)
+    @load_balancers ||= filter_my_region(@lbs.list_all)
   end
 
   protected

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -122,7 +122,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     @instances_cache ||= if refs.size > record_limit
                            set = Set.new(refs)
-                           collect_inventory(:instances) { gather_data_for_this_region(@vmm) }.select do |instance|
+                           collect_inventory(:instances) { filter_my_region(@vmm.list_all) }.select do |instance|
                              uid = File.join(subscription_id,
                                              instance.resource_group.downcase,
                                              instance.type.downcase,
@@ -194,7 +194,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     set = Set.new(refs)
 
-    collect_inventory_targeted(:private_images) { gather_data_for_this_region(@sas, 'list_all_private_images') }.select do |image|
+    collect_inventory_targeted(:private_images) { @sas.list_all_private_images(:location => @ems.provider_region) }.select do |image|
       set.include?(image.uri)
     end
   rescue ::Azure::Armrest::Exception => err
@@ -208,7 +208,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     if refs.size > record_limit
       set = Set.new(refs)
-      collect_inventory(:managed_images) { gather_data_for_this_region(@mis) }.select do |image|
+      collect_inventory(:managed_images) { filter_my_region(@mis.list_all) }.select do |image|
         set.include?(image.id.downcase)
       end
     else
@@ -244,7 +244,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
           )
         end
       else
-        gather_data_for_this_region(@vmis)
+        filter_my_region(@vmis.list_all)
       end
     end
 
@@ -294,7 +294,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     if refs.size > record_limit
       set = Set.new(refs)
-      collect_inventory(:cloud_networks) { gather_data_for_this_region(@vns) }.select do |cloud_network|
+      collect_inventory(:cloud_networks) { filter_my_region(@vns.list_all) }.select do |cloud_network|
         set.include?(cloud_network.id)
       end
     else
@@ -315,7 +315,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     if refs.size > record_limit
       set = Set.new(refs)
-      collect_inventory(:security_groups) { gather_data_for_this_region(@nsg) }.select do |security_group|
+      collect_inventory(:security_groups) { filter_my_region(@nsg.list_all) }.select do |security_group|
         set.include?(security_group.id)
       end
     else
@@ -358,7 +358,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     @load_balancers_cache ||= if refs.size > record_limit
                                 set = Set.new(refs)
-                                collect_inventory(:load_balancers) { @load_balancers ||= gather_data_for_this_region(@lbs) }.select do |load_balancer|
+                                collect_inventory(:load_balancers) { @load_balancers ||= filter_my_region(@lbs.list_all) }.select do |load_balancer|
                                   set.include?(load_balancer.id)
                                 end
                               else
@@ -379,7 +379,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     @floating_ips_cache ||= if refs.size > record_limit
                               set = Set.new(refs)
-                              collect_inventory(:floating_ips) { @floating_ips_cache ||= gather_data_for_this_region(@ips) }.select do |floating_ip|
+                              collect_inventory(:floating_ips) { @floating_ips_cache ||= filter_my_region(@ips.list_all) }.select do |floating_ip|
                                 set.include?(floating_ip.id)
                               end
                             else

--- a/spec/models/manageiq/providers/azure/refresh_helper_methods_spec.rb
+++ b/spec/models/manageiq/providers/azure/refresh_helper_methods_spec.rb
@@ -67,30 +67,23 @@ describe ManageIQ::Providers::Azure::RefreshHelperMethods do
     end
   end
 
-  context "gather_data_for_region" do
-    it "requires a service name" do
-      expect { @ems_azure.gather_data_for_this_region }.to raise_error(ArgumentError)
-    end
-
-    it "accepts an optional method name" do
-      allow(virtual_machine_service).to receive(:list_all).and_return([])
-      expect(@ems_azure.gather_data_for_this_region(virtual_machine_service, 'list_all')).to eql([])
-    end
-
+  context "filter_my_region" do
     it "returns the expected results for matching location" do
       allow(virtual_machine_service).to receive(:list_all).and_return([virtual_machine_eastus])
-      expect(@ems_azure.gather_data_for_this_region(virtual_machine_service, 'list_all')).to eql([virtual_machine_eastus])
+      expect(
+        @ems_azure.filter_my_region(virtual_machine_service.list_all)
+      ).to eql([virtual_machine_eastus])
     end
 
     it "returns the expected results for non-matching location" do
       allow(virtual_machine_service).to receive(:list_all).and_return([virtual_machine_southindia])
-      expect(@ems_azure.gather_data_for_this_region(virtual_machine_service, 'list_all')).to eql([])
+      expect(@ems_azure.filter_my_region(virtual_machine_service.list_all)).to eql([])
     end
 
     it "ignores case when searching for matching locations" do
       @ems_azure.provider_region = 'southindia'
       allow(virtual_machine_service).to receive(:list_all).and_return([virtual_machine_southindia])
-      expect(@ems_azure.gather_data_for_this_region(virtual_machine_service, 'list_all')).to eql([virtual_machine_southindia])
+      expect(@ems_azure.filter_my_region(virtual_machine_service.list_all)).to eql([virtual_machine_southindia])
     end
   end
 end


### PR DESCRIPTION
This method is a fairly useless wrapper which simply sends the method_name and didn't really share any code to filter by region anyway.

The `else` condition was added to handle stacks, but stack collection has been rewritten anyway and no longer uses this method