### PR TITLE
Fix network ports memoization and remove unused `RefreshHelperMethods` methods

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -104,7 +104,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
   end
 
   def network_ports
-    @network_interfaces ||= collect_inventory(:network_ports) { filter_my_region(@nis.list_all) }
+    @network_ports ||= collect_inventory(:network_ports) { filter_my_region(@nis.list_all) }
   end
 
   def network_routers

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -336,7 +336,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     @network_ports_cache ||= if refs.size > record_limit
                                set = Set.new(refs)
-                               collect_inventory(:network_ports) { @network_ports_cache ||= get_network_interfaces }.select do |network_port|
+                               collect_inventory(:network_ports) { filter_my_region(@nis.list_all) }.select do |network_port|
                                  set.include?(network_port.id)
                                end
                              else

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -95,10 +95,6 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     network_interfaces.find_all { |nic| nic_ids.include?(nic.id) }
   end
 
-  def get_network_interfaces
-    @network_interfaces ||= filter_my_region(@nis.list_all)
-  end
-
   def ip_addresses
     @ip_addresses ||= filter_my_region(@ips.list_all)
   end

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -89,20 +89,6 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     "/subscriptions/#{object.subscription_id}/resourcegroups/#{object.resource_group}".downcase
   end
 
-  # TODO(lsmola) NetworkManager, move below methods under NetworkManager, once it is not needed in Cloudmanager
-  def get_vm_nics(instance)
-    nic_ids = instance.properties.network_profile.network_interfaces.collect(&:id)
-    network_interfaces.find_all { |nic| nic_ids.include?(nic.id) }
-  end
-
-  def ip_addresses
-    @ip_addresses ||= filter_my_region(@ips.list_all)
-  end
-
-  def get_network_routers
-    @network_routers ||= filter_my_region(@rts.list_all)
-  end
-
   # Create the necessary service classes and lock down their api-version
   # strings using the config/settings.yml from the provider repo.
 


### PR DESCRIPTION
Fix the `network_ports` method memoizing `@network_interfaces` and remove a number of unused methods
Note the whole point of the `RefreshHelperMethods` module was to share common code between graph and classic refresh and can probably be moved into the `Azure::Inventory::Collector` and `Azure::Inventory::Parser` methods