### PR TITLE
Handle Forbidden errors fetching stack templates

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -183,7 +183,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::In
     init_template_hash(deployment, content.to_s).tap do |template_hash|
       @template_directs[deployment.id] = template_hash
     end
-  rescue ::Azure::Armrest::ConflictException
+  rescue ::Azure::Armrest::ConflictException, ::Azure::Armrest::ForbiddenException
     # Templates were not saved for deployments created before 03/20/2016
     nil
   end

--- a/app/models/manageiq/providers/azure/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/network_manager.rb
@@ -291,6 +291,8 @@ class ManageIQ::Providers::Azure::Inventory::Parser::NetworkManager < ManageIQ::
       uid = ip.id
 
       network_port_id = floating_ip_network_port_id(ip)
+      next if network_port_id.nil?
+
       if load_balancer_network_port?(network_port_id)
         network_port = persister.network_ports.lazy_find("#{network_port_id}/nic1")
       else


### PR DESCRIPTION
```
[Azure::Armrest::ForbiddenException]: The client CLIENT_ID with object id OBJECT_ID has permission to perform action 'Microsoft.Resources/deployments/exportTemplate/action' on scope '/subscriptions/SUBSCRIPTION_ID/resourceGroups/providers/Microsoft.Resources/deployments/storage'; however, the access is denied because of the deny assignment with name DENY_ASSIGNMENT_NAME and Id DENY_ASSIGNMENT_ID at scope '/subscriptions/SUBSCRIPTION_ID/resourcegroups'.
```