### PR TITLE
Collect filtered marked images by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,7 +46,7 @@
   :azure:
     # If get_market_images is enabled with no filters, all public images will be added
     # This will cause performance issues during refresh and at places in the UI where images are listed
-    :get_market_images: false
+    :get_market_images: true
     # Optionally collecting private images [Graph refresh only]
     :get_private_images: true
     :market_image_urns:

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -157,7 +157,7 @@ module AzureRefresherSpecCommon
       :flavor                            => 198,
       :floating_ip                       => 9,
       :guest_device                      => 0,
-      :hardware                          => 10,
+      :hardware                          => 21,
       :load_balancer                     => 2,
       :load_balancer_pool                => 1,
       :load_balancer_pool_member         => 2,
@@ -166,7 +166,7 @@ module AzureRefresherSpecCommon
       :load_balancer_listener_pool       => 1,
       :load_balancer_health_check        => 3,
       :load_balancer_health_check_member => 2,
-      :miq_template                      => 1,
+      :miq_template                      => 12,
       :network                           => 16,
       :network_port                      => 11,
       :network_router                    => 1,
@@ -180,7 +180,7 @@ module AzureRefresherSpecCommon
       :resource_group                    => 8,
       :security_group                    => 5,
       :vm                                => 9,
-      :vm_or_template                    => 10,
+      :vm_or_template                    => 21,
     }
   end
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -37,17 +37,14 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
           ]
         end
 
-        let(:settings) do
-          {:ems_refresh => {:azure => {:get_market_images => true, :market_image_urns => urns}}}
-        end
-
-        it "does not collect marketplace images by default" do
+        it "does not collect marketplace images if disabled by settings" do
+          stub_settings_merge(:ems_refresh => {:azure => {:get_market_images => false}})
           setup_ems_and_cassette(refresh_settings)
           expect(VmOrTemplate.where(:publicly_available => true).count).to eql(0)
         end
 
         it "collects only the marketplace images from the settings file if present" do
-          stub_settings_merge(settings)
+          stub_settings_merge(:ems_refresh => {:azure => {:get_market_images => true, :market_image_urns => urns}})
           setup_ems_and_cassette(refresh_settings)
           expect(VmOrTemplate.where(:publicly_available => true).count).to eql(4)
         end


### PR DESCRIPTION
There are over 30k maket images so it isn't feasible to refresh all of them but we have a filtered list of the popular operating systems and recent versions so by default only the images in the filtered list are saved.

Follow-up to: https://github.com/ManageIQ/manageiq-providers-azure/pull/525#issuecomment-1277825018