### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -1,23 +1,4 @@
 class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManager
-  require_nested :AvailabilityZone
-  require_nested :CloudDatabase
-  require_nested :CloudDatabaseServer
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Flavor
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :RefreshWorker
-  require_nested :ResourceGroup
-  require_nested :Refresher
-  require_nested :Vm
-  require_nested :Template
-  require_nested :Provision
-  require_nested :ProvisionWorkflow
-  require_nested :OrchestrationStack
-  require_nested :OrchestrationTemplate
-  require_nested :OrchestrationServiceOptionConverter
-
   include ManageIQ::Providers::Azure::ManagerMixin
 
   alias_attribute :azure_tenant_id, :uid_ems

--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Azure::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   # Override the superclass method in order to disable event collection for
   # providers that do not support it.
   #

--- a/app/models/manageiq/providers/azure/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Azure::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "azure"
 
   def friendly_name

--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
   require_dependency 'manageiq/providers/azure/cloud_manager/orchestration_stack/status'
-  include_concern 'ManageIQ::Providers::Azure::CloudManager::Deployment'
+  include ManageIQ::Providers::Azure::CloudManager::Deployment
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
     resource_group, create_options = make_create_options(template, options)

--- a/app/models/manageiq/providers/azure/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::Azure::CloudManager::Provision < ManageIQ::Providers::CloudManager::Provision
-  include_concern 'Cloning'
-  include_concern 'Configuration'
-  include_concern 'OptionsHelper'
-  include_concern 'StateMachine'
+  include Cloning
+  include Configuration
+  include OptionsHelper
+  include StateMachine
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Azure::CloudManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/scanning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/scanning.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Azure::CloudManager::Scanning
-  require_nested :Job
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/template.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Azure::CloudManager::Template < ::ManageIQ::Providers::CloudManager::Template
-  include_concern 'ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared'
+  include ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
 
   supports :provisioning do
     if ext_management_system

--- a/app/models/manageiq/providers/azure/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
-  include_concern 'Operations'
-  include_concern 'ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared'
+  include Operations
+  include ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
 
   supports :capture
 

--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Azure::CloudManager::Vm::Operations
   extend ActiveSupport::Concern
-  include_concern 'Power'
+  include Power
 
   included do
     supports :terminate do

--- a/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm_or_template_shared.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared
   extend ActiveSupport::Concern
-  include_concern 'Scanning'
+  include Scanning
   SSA_SNAPSHOT_SUFFIX = "_SSA_SNAPSHOT".freeze
   SSA_NAME_MAX        = 80
 

--- a/app/models/manageiq/providers/azure/container_manager.rb
+++ b/app/models/manageiq/providers/azure/container_manager.rb
@@ -1,17 +1,6 @@
 ManageIQ::Providers::Kubernetes::ContainerManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Azure::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
-  require_nested :Container
-  require_nested :ContainerGroup
-  require_nested :ContainerNode
-  require_nested :ContainerTemplate
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :ServiceInstance
-  require_nested :ServiceOffering
-
   supports :create
 
   class << self

--- a/app/models/manageiq/providers/azure/container_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/azure/container_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Azure::ContainerManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_azure_aks
   end

--- a/app/models/manageiq/providers/azure/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/azure/container_manager/refresh_worker.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::Azure::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-  require_nested :WatchThread
-
   def self.settings_name
     :ems_refresh_worker_azure_aks
   end

--- a/app/models/manageiq/providers/azure/inventory.rb
+++ b/app/models/manageiq/providers/azure/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Azure::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
   def self.default_manager_name

--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::Azure::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :ContainerManager
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :TargetCollection
-
   # TODO: cleanup later when old refresh is deleted
   include ManageIQ::Providers::Azure::RefreshHelperMethods
   include Vmdb::Logging

--- a/app/models/manageiq/providers/azure/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Azure::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/azure/inventory/parser.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Azure::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :ContainerManager
-  require_nested :CloudManager
-  require_nested :NetworkManager
-
   include Vmdb::Logging
 
   TYPE_DEPLOYMENT = "microsoft.resources/deployments".freeze

--- a/app/models/manageiq/providers/azure/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Azure::Inventory::Parser::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/azure/inventory/persister.rb
+++ b/app/models/manageiq/providers/azure/inventory/persister.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::Azure::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :ContainerManager
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :TargetCollection
-
   attr_reader :collector
 
   attr_reader :stack_resources_secondary_index, :cloud_subnet_network_ports_secondary_index

--- a/app/models/manageiq/providers/azure/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/persister/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Azure::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/azure/network_manager.rb
+++ b/app/models/manageiq/providers/azure/network_manager.rb
@@ -1,17 +1,4 @@
 class ManageIQ::Providers::Azure::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :FloatingIp
-  require_nested :LoadBalancer
-  require_nested :LoadBalancerHealthCheck
-  require_nested :LoadBalancerListener
-  require_nested :LoadBalancerPool
-  require_nested :LoadBalancerPoolMember
-  require_nested :NetworkPort
-  require_nested :NetworkRouter
-  require_nested :Refresher
-  require_nested :SecurityGroup
-
   include ManageIQ::Providers::Azure::ManagerMixin
 
   has_many :floating_ips, :foreign_key => :ems_id, :dependent => :destroy,


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854