### PR TITLE
Fix Azure CloudSubnet missing address_prefix

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@
       :storage_disk: "2017-03-30"
       :template_deployment: "2017-08-01"
       :virtual_machine: "2017-12-01"
-      :virtual_network: "2017-11-01"
+      :virtual_network: "2023-11-01"
     :blacklisted_event_names:
       - storageAccounts_listKeys_BeginRequest
       - storageAccounts_listKeys_EndRequest


### PR DESCRIPTION
Azure moved from a single static Subnet.addressPrefix to an array of addressPrefixes in the newer API version.  The older API version would return no addressPrefix causing a NoMethodError.

Older Subnets still have the old singular addressPrefix so we have to support both
![image](https://github.com/user-attachments/assets/f0780648-cddf-4fe3-9c4e-5e784748474c)


Fixes https://github.com/ManageIQ/manageiq-providers-azure/issues/547
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
