### PR TITLE
Fix Azure NetworkManager refresh disconnecting managed_images

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager.rb
+++ b/app/models/manageiq/providers/azure/network_manager.rb
@@ -25,6 +25,10 @@ class ManageIQ::Providers::Azure::NetworkManager < ManageIQ::Providers::NetworkM
            :to        => :parent_manager,
            :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::Azure::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "azure_network".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -72,6 +72,9 @@
       # Strategy for saving, another allowed is batch, doing batch SQL queries [Graph refresh only]
       :saver_strategy: default
   :azure_network:
+    # Disable scheduled full refresh for the network manager as this will be
+    # refreshed automatically by the parent cloud manager.
+    :refresh_interval: 0
     :inventory_collections:
       :saver_strategy: default
 :http_proxy:


### PR DESCRIPTION
All refreshes should be done via the CloudManager, instance methods are delegated to the network_manager's parent_manager however the class-level refresh_ems method was not being delegated causing failures and disconnected inventory.

NOTE this was called via the scheduled `refresh_all_ems_timer` method, this currently goes through all permitted subclasses which includes the child managers like these Network and Storage managers under a parent cloud manager.  At best this is a duplicate full refresh and at worst in this case it exposes bugs like this.  I'd like to tackle running a full refresh on a timer only for the "primary" class (where that is going to differ provider to provider) in a separate pr.

Fixes https://github.com/ManageIQ/manageiq-providers-azure/issues/563
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
